### PR TITLE
feat: rename status → sendStatus and enable draft autosave on Broadcasts

### DIFF
--- a/src/collections/Broadcasts/components/SendButton.tsx
+++ b/src/collections/Broadcasts/components/SendButton.tsx
@@ -16,7 +16,7 @@ const SendButton: React.FC = () => {
 
   const { id, savedDocumentData } = useDocumentInfo()
 
-  const status = (savedDocumentData?.status ?? 'draft') as BroadcastStatus
+  const status = (savedDocumentData?.sendStatus ?? 'draft') as BroadcastStatus
   const resendBroadcastId = savedDocumentData?.resendBroadcastId as string | undefined
 
   const isSent = status === 'sent'

--- a/src/collections/Broadcasts/handlers/send.ts
+++ b/src/collections/Broadcasts/handlers/send.ts
@@ -24,7 +24,7 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
     return Response.json({ error: 'Broadcast not found' }, { status: 404 })
   }
 
-  if (broadcast.status === 'sent') {
+  if (broadcast.sendStatus === 'sent') {
     return Response.json({ error: 'Broadcast has already been sent' }, { status: 400 })
   }
 
@@ -68,7 +68,7 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
         collection: 'broadcasts',
         id,
         data: {
-          status: 'failed',
+          sendStatus: 'failed',
           errorMessage: result.message,
         },
       })
@@ -87,7 +87,7 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
       id,
       data: {
         resendBroadcastId: result.resendBroadcastId,
-        status: isScheduled ? 'scheduled' : 'sent',
+        sendStatus: isScheduled ? 'scheduled' : 'sent',
         ...(isScheduled ? {} : { sentAt: now }),
         errorMessage: '',
       },
@@ -100,7 +100,7 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
     await req.payload.update({
       collection: 'broadcasts',
       id,
-      data: { status: 'failed', errorMessage: message },
+      data: { sendStatus: 'failed', errorMessage: message },
     })
 
     return Response.json({ error: message }, { status: 500 })

--- a/src/collections/Broadcasts/index.ts
+++ b/src/collections/Broadcasts/index.ts
@@ -6,9 +6,14 @@ import { weeklyPostsHandler } from './handlers/weeklyPosts'
 
 export const Broadcasts: CollectionConfig = {
   slug: 'broadcasts',
+  versions: {
+    drafts: {
+      autosave: { interval: 100 },
+    },
+  },
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['title', 'type', 'status', 'sentAt', 'updatedAt'],
+    defaultColumns: ['title', 'type', 'sendStatus', 'sentAt', 'updatedAt'],
     group: 'Email',
   },
   access: {
@@ -140,7 +145,7 @@ export const Broadcasts: CollectionConfig = {
       type: 'row',
       fields: [
         {
-          name: 'status',
+          name: 'sendStatus',
           type: 'select',
           defaultValue: 'draft',
           options: [

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -204,7 +204,7 @@ export interface Broadcast {
   /**
    * Managed by the system — updated after Resend API calls
    */
-  status?: ('draft' | 'scheduled' | 'sent' | 'failed') | null;
+  sendStatus?: ('draft' | 'scheduled' | 'sent' | 'failed') | null;
   /**
    * ID returned by Resend after the broadcast is created
    */
@@ -223,6 +223,7 @@ export interface Broadcast {
   errorMessage?: string | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1142,13 +1143,14 @@ export interface BroadcastsSelect<T extends boolean = true> {
   body?: T;
   post?: T;
   posts?: T;
-  status?: T;
+  sendStatus?: T;
   resendBroadcastId?: T;
   scheduledAt?: T;
   sentAt?: T;
   errorMessage?: T;
   updatedAt?: T;
   createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
## Summary
- Renames `status` → `sendStatus` on the Broadcasts collection to avoid collision with Payload's own `_status` draft field
- Enables `versions.drafts.autosave` (100ms interval) on Broadcasts — required for Live Preview in Phase 5
- Updates all references in the send handler, SendButton component, and regenerated `payload-types.ts`

## Test plan
- [x] Create a new broadcast — confirm autosave indicator appears in the admin toolbar
- [x] Send a broadcast — confirm `sendStatus` updates to `sent` and the SendButton reflects the sent state
- [x] Attempt to send an already-sent broadcast — confirm the 400 error guard still works
- [x] Confirm `sendStatus` and Payload's `_status` coexist without conflict in the admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)