### PR TITLE
refactor: extract assembleBroadcastEmail into shared utility

### DIFF
--- a/src/collections/Broadcasts/handlers/send.ts
+++ b/src/collections/Broadcasts/handlers/send.ts
@@ -1,9 +1,7 @@
 import type { PayloadHandler } from 'payload'
-import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html'
-import type { Broadcast, EmailLayout, Post } from '../../../payload-types'
+import type { Broadcast } from '../../../payload-types'
 import { createAndSendResendBroadcast, buildFromAddress } from '../../../resend/broadcasts'
-import { renderEmailTemplate } from '../../../resend/template'
-import { renderPostCard } from '../../../resend/renderPostCard'
+import { assembleBroadcastEmail } from '../../../resend/assembleBroadcastEmail'
 
 export const sendBroadcastHandler: PayloadHandler = async (req) => {
   const id = req.routeParams?.id as string | undefined
@@ -54,7 +52,7 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
   }
 
   try {
-    const html = await assembleBroadcastEmail(req, broadcast)
+    const html = await assembleBroadcastEmail(req.payload, broadcast)
 
     const result = await createAndSendResendBroadcast({
       audienceId,
@@ -107,41 +105,4 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
 
     return Response.json({ error: message }, { status: 500 })
   }
-}
-
-async function assembleBroadcastEmail(
-  req: Parameters<PayloadHandler>[0],
-  broadcast: Broadcast,
-): Promise<string> {
-  const bodyHtml = broadcast.body
-    ? convertLexicalToHTML({ data: broadcast.body })
-    : ''
-
-  const postCardsHtml = buildPostCardsHtml(broadcast)
-
-  const layout = await req.payload.findGlobal({
-    slug: 'email-layout',
-    depth: 1,
-  }) as EmailLayout
-
-  return renderEmailTemplate(bodyHtml + postCardsHtml, layout)
-}
-
-function buildPostCardsHtml(broadcast: Broadcast): string {
-  if (broadcast.type === 'single_post') {
-    const post = broadcast.post
-    if (!post || typeof post === 'number') return ''
-    return renderPostCard(post as Post)
-  }
-
-  if (broadcast.type === 'weekly_digest') {
-    const posts = broadcast.posts
-    if (!posts?.length) return ''
-    return posts
-      .filter((p): p is Post => typeof p !== 'number')
-      .map(renderPostCard)
-      .join('\n')
-  }
-
-  return ''
 }

--- a/src/resend/assembleBroadcastEmail.ts
+++ b/src/resend/assembleBroadcastEmail.ts
@@ -1,0 +1,53 @@
+import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html'
+import type { Payload } from 'payload'
+import type { Broadcast, EmailLayout, Post } from '../payload-types'
+import { renderEmailTemplate } from './template'
+import { renderPostCard } from './renderPostCard'
+
+type AssembleOptions = {
+  preview?: boolean
+}
+
+export async function assembleBroadcastEmail(
+  payload: Payload,
+  broadcast: Broadcast,
+  options: AssembleOptions = {},
+): Promise<string> {
+  const bodyHtml = broadcast.body ? convertLexicalToHTML({ data: broadcast.body }) : ''
+  const postCardsHtml = buildPostCardsHtml(broadcast)
+
+  const layout = (await payload.findGlobal({
+    slug: 'email-layout',
+    depth: 1,
+  })) as EmailLayout
+
+  const html = renderEmailTemplate(bodyHtml + postCardsHtml, layout)
+
+  if (options.preview) {
+    return html.replace(
+      /href="\{{{RESEND_UNSUBSCRIBE_URL}}}"[^>]*>[^<]*/,
+      'href="#">[Unsubscribe — preview only]',
+    )
+  }
+
+  return html
+}
+
+function buildPostCardsHtml(broadcast: Broadcast): string {
+  if (broadcast.type === 'single_post') {
+    const post = broadcast.post
+    if (!post || typeof post === 'number') return ''
+    return renderPostCard(post as Post)
+  }
+
+  if (broadcast.type === 'weekly_digest') {
+    const posts = broadcast.posts
+    if (!posts?.length) return ''
+    return posts
+      .filter((p): p is Post => typeof p !== 'number')
+      .map(renderPostCard)
+      .join('\n')
+  }
+
+  return ''
+}


### PR DESCRIPTION
## Summary
- Extracts `assembleBroadcastEmail` and `buildPostCardsHtml` from `handlers/send.ts` into `src/resend/assembleBroadcastEmail.ts`
- Accepts a `payload` instance directly (instead of the full request object) so any server context can call it
- Adds a `preview?: boolean` option — when `true`, replaces the `{{{RESEND_UNSUBSCRIBE_URL}}}` Resend placeholder with `href="#"` and the text `[Unsubscribe — preview only]` so in-browser previews render cleanly
- Updates `send.ts` to import from the new utility with no behavior change for actual sends

## Test plan
- [ ] Send a broadcast and confirm it still assembles and delivers correctly (no regression)
- [ ] Verify the unsubscribe link placeholder is untouched in sent email HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)