### PR TITLE
feat: add broadcast email preview route

### DIFF
--- a/src/app/(email-preview)/broadcast-preview/[id]/page.client.tsx
+++ b/src/app/(email-preview)/broadcast-preview/[id]/page.client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { RefreshRouteOnSave } from '@payloadcms/live-preview-react'
+import { useRouter } from 'next/navigation'
+
+type Props = {
+  serverURL: string
+}
+
+export default function BroadcastPreviewClient({ serverURL }: Props) {
+  const router = useRouter()
+  return <RefreshRouteOnSave refresh={router.refresh} serverURL={serverURL} />
+}

--- a/src/app/(email-preview)/broadcast-preview/[id]/page.tsx
+++ b/src/app/(email-preview)/broadcast-preview/[id]/page.tsx
@@ -1,0 +1,48 @@
+import { headers } from 'next/headers'
+import { notFound } from 'next/navigation'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { assembleBroadcastEmail } from '@/resend/assembleBroadcastEmail'
+import { getServerSideURL } from '@/utilities/getURL'
+import BroadcastPreviewClient from './page.client'
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function BroadcastPreviewPage({ params }: Props) {
+  const { id } = await params
+  const payload = await getPayload({ config: configPromise })
+
+  const { user } = await payload.auth({ headers: await headers() })
+
+  if (!user) {
+    return (
+      <html lang="en">
+        <body style={{ margin: 0, padding: '24px', fontFamily: 'Arial, sans-serif' }}>
+          <p>Unauthorized — please log in to the admin panel.</p>
+        </body>
+      </html>
+    )
+  }
+
+  const broadcast = await payload.findByID({
+    collection: 'broadcasts',
+    id,
+    draft: true,
+    depth: 2,
+    overrideAccess: false,
+    user,
+  })
+
+  if (!broadcast) notFound()
+
+  const html = await assembleBroadcastEmail(payload, broadcast, { preview: true })
+
+  return (
+    <>
+      <BroadcastPreviewClient serverURL={getServerSideURL()} />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </>
+  )
+}

--- a/src/app/(email-preview)/layout.tsx
+++ b/src/app/(email-preview)/layout.tsx
@@ -1,0 +1,7 @@
+export default function EmailPreviewLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0 }}>{children}</body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- Creates `src/app/(email-preview)/layout.tsx` — a minimal layout with no site header/footer, so the email HTML renders standalone inside the Payload Live Preview iframe
- Creates `src/app/(email-preview)/broadcast-preview/[id]/page.tsx` — server component that verifies the Payload session, fetches the broadcast draft at `depth: 2`, and renders the assembled email HTML via `dangerouslySetInnerHTML`
- Creates `src/app/(email-preview)/broadcast-preview/[id]/page.client.tsx` — uses `RefreshRouteOnSave` from `@payloadcms/live-preview-react` to call `router.refresh()` on every autosave postMessage from the admin panel

## Test plan
- [ ] Navigate to `/broadcast-preview/{id}` in the browser while logged in — confirm the email HTML renders correctly with no site header/footer
- [ ] Navigate to `/broadcast-preview/{id}` while logged out — confirm the unauthorized message appears
- [ ] Navigate to `/broadcast-preview/invalid-id` — confirm a 404 is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)