### PR TITLE
feat: wire Live Preview into Broadcasts collection

### DIFF
--- a/src/collections/Broadcasts/index.ts
+++ b/src/collections/Broadcasts/index.ts
@@ -3,6 +3,7 @@ import { lexicalEditor } from '@payloadcms/richtext-lexical'
 
 import { sendBroadcastHandler } from './handlers/send'
 import { weeklyPostsHandler } from './handlers/weeklyPosts'
+import { getServerSideURL } from '../../utilities/getURL'
 
 export const Broadcasts: CollectionConfig = {
   slug: 'broadcasts',
@@ -15,6 +16,12 @@ export const Broadcasts: CollectionConfig = {
     useAsTitle: 'title',
     defaultColumns: ['title', 'type', 'sendStatus', 'sentAt', 'updatedAt'],
     group: 'Email',
+    livePreview: {
+      url: ({ data }) => {
+        if (!data?.id || data?.sendStatus === 'sent') return null
+        return `${getServerSideURL()}/broadcast-preview/${data.id}`
+      },
+    },
   },
   access: {
     read: ({ req: { user } }) => Boolean(user),

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -88,6 +88,12 @@ export default buildConfig({
           width: 1440,
           height: 900,
         },
+        {
+          label: 'Email',
+          name: 'email',
+          width: 600,
+          height: 900,
+        },
       ],
     },
   },


### PR DESCRIPTION
## Summary
- Adds `admin.livePreview` to the Broadcasts collection with a URL function pointing to `/broadcast-preview/{id}`
- Returns `null` from the URL function when `sendStatus === 'sent'`, which disables the eye icon on already-sent broadcasts
- Adds an `Email` breakpoint at 600px width to the global `livePreview.breakpoints` in `payload.config.ts` — the standard max-width for email clients

## Test plan
- [ ] Open a draft broadcast in the admin — confirm the eye icon appears in the toolbar
- [ ] Click the eye icon — confirm the Live Preview panel opens with the email rendered in an iframe
- [ ] Edit the broadcast body — confirm the preview refreshes automatically after each autosave
- [ ] Switch to the Email breakpoint (600px) — confirm the preview scales correctly
- [ ] Open a broadcast with `sendStatus: sent` — confirm the eye icon does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)