### PR TITLE
closes 75 - useDebounce on Post Title and Slug Generation

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -30,6 +30,7 @@ import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c08
 import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { SlugField as SlugField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
+import { default as default_df7eb999ede7363ee297ab1263291c5c } from '@/collections/Posts/components/PostTitleField'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_000ace4bf1f9ff748ac15c677b9ef3f5 } from '@/collections/Posts/components/PostSlugField'
 import { default as default_72de2780787708611145fd8a30acae54 } from '@/collections/Posts/components/DraftBroadcastButton'
@@ -79,6 +80,7 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/next/client#SlugField": SlugField_2b8867833a34864a02ddf429b0728a40,
+  "@/collections/Posts/components/PostTitleField#default": default_df7eb999ede7363ee297ab1263291c5c,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@/collections/Posts/components/PostSlugField#default": default_000ace4bf1f9ff748ac15c677b9ef3f5,
   "@/collections/Posts/components/DraftBroadcastButton#default": default_72de2780787708611145fd8a30acae54,

--- a/src/collections/Broadcasts/handlers/send.ts
+++ b/src/collections/Broadcasts/handlers/send.ts
@@ -14,11 +14,11 @@ export const sendBroadcastHandler: PayloadHandler = async (req) => {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const broadcast = await req.payload.findByID({
+  const broadcast = (await req.payload.findByID({
     collection: 'broadcasts',
     id,
     depth: 2,
-  })
+  })) as Broadcast
 
   if (!broadcast) {
     return Response.json({ error: 'Broadcast not found' }, { status: 404 })

--- a/src/collections/Posts/components/PostTitleField.tsx
+++ b/src/collections/Posts/components/PostTitleField.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FieldLabel, TextInput, useField } from '@payloadcms/ui'
-import { useEffect, useState } from 'react'
+import { type ChangeEvent, useEffect, useState } from 'react'
 import { useDebounce } from '@/utilities/useDebounce'
 
 type Props = {
@@ -24,7 +24,7 @@ const PostTitleField: React.FC<Props> = ({ field, path, readOnly }) => {
     if (debouncedValue !== formValue) {
       setValue(debouncedValue)
     }
-  }, [debouncedValue])
+  }, [debouncedValue, formValue, setValue])
 
   return (
     <div>
@@ -34,7 +34,7 @@ const PostTitleField: React.FC<Props> = ({ field, path, readOnly }) => {
         required={field.required}
       />
       <TextInput
-        onChange={(e) => setLocalValue(e.target.value)}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setLocalValue(e.target.value)}
         path={resolvedPath}
         readOnly={readOnly}
         value={localValue}

--- a/src/collections/Posts/components/PostTitleField.tsx
+++ b/src/collections/Posts/components/PostTitleField.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { FieldLabel, TextInput, useField } from '@payloadcms/ui'
+import { useEffect, useState } from 'react'
+import { useDebounce } from '@/utilities/useDebounce'
+
+type Props = {
+  field: { label?: string; name: string; required?: boolean }
+  path: string
+  readOnly?: boolean
+}
+
+const PostTitleField: React.FC<Props> = ({ field, path, readOnly }) => {
+  const resolvedPath = path || field.name
+  const { value: formValue, setValue } = useField<string>({ path: resolvedPath })
+
+  // Local state updates immediately on every keystroke — no flicker
+  const [localValue, setLocalValue] = useState(formValue ?? '')
+
+  // Only commit to the form (triggering autosave + slug generation) after 600ms idle
+  const debouncedValue = useDebounce(localValue, 600)
+
+  useEffect(() => {
+    if (debouncedValue !== formValue) {
+      setValue(debouncedValue)
+    }
+  }, [debouncedValue])
+
+  return (
+    <div>
+      <FieldLabel
+        htmlFor={`field-${resolvedPath}`}
+        label={field.label}
+        required={field.required}
+      />
+      <TextInput
+        onChange={(e) => setLocalValue(e.target.value)}
+        path={resolvedPath}
+        readOnly={readOnly}
+        value={localValue}
+      />
+    </div>
+  )
+}
+
+export default PostTitleField

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -74,6 +74,11 @@ export const Posts: CollectionConfig<'posts'> = {
       name: 'title',
       type: 'text',
       required: true,
+      admin: {
+        components: {
+          Field: '@/collections/Posts/components/PostTitleField',
+        },
+      },
     },
     {
       type: 'tabs',


### PR DESCRIPTION
Now when the User updates the title of the post, we use `useDebounce` to trigger 2 actions afterward:
1 - Update the Header of the Post
2 - Update the Slug of the Post.