### PR TITLE
closes #78 - Post Categories are used in SEO title generation

### DIFF
--- a/src/collections/Posts/hooks/syncCategoriesToMetaTitle.ts
+++ b/src/collections/Posts/hooks/syncCategoriesToMetaTitle.ts
@@ -1,0 +1,53 @@
+import type { CollectionBeforeChangeHook } from 'payload'
+import type { Category, Post } from '../../../payload-types'
+
+/**
+ * Appends category names to the meta title set by syncTitleToMetaTitle.
+ * Must run AFTER syncTitleToMetaTitle in the beforeChange hooks array.
+ *
+ * Input:  "{Site Name} | {Post Title}"   (set by syncTitleToMetaTitle)
+ * Output: "{Site Name} | {Post Title} | Category1, Category2"
+ *
+ * If the post has no categories, or meta.title is not yet set, returns data unchanged.
+ */
+export const syncCategoriesToMetaTitle: CollectionBeforeChangeHook<Post> = async ({
+  data,
+  req: { payload },
+}) => {
+  const baseTitle = data.meta?.title
+  if (!baseTitle) return data
+
+  const rawCategories = data.categories ?? []
+
+  const categoryIds = rawCategories.filter((c): c is number => typeof c === 'number')
+  const populatedCategories = rawCategories.filter((c): c is Category => typeof c !== 'number')
+
+  if (categoryIds.length === 0 && populatedCategories.length === 0) return data
+
+  // Fetch titles for any categories that arrived as IDs (the normal admin save path)
+  let fetchedTitles: string[] = []
+  if (categoryIds.length > 0) {
+    const result = await payload.find({
+      collection: 'categories',
+      where: { id: { in: categoryIds } },
+      depth: 0,
+      limit: categoryIds.length,
+    })
+    fetchedTitles = result.docs.map((c) => c.title)
+  }
+
+  const allTitles = [
+    ...populatedCategories.map((c) => c.title),
+    ...fetchedTitles,
+  ].filter(Boolean)
+
+  if (allTitles.length === 0) return data
+
+  return {
+    ...data,
+    meta: {
+      ...data.meta,
+      title: `${baseTitle} | ${allTitles.join(', ')}`,
+    },
+  }
+}

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -17,6 +17,7 @@ import { MediaBlock } from '../../blocks/MediaBlock/config'
 import { generatePreviewPath } from '../../utilities/generatePreviewPath'
 import { populateAuthors } from './hooks/populateAuthors'
 import { revalidateDelete, revalidatePost } from './hooks/revalidatePost'
+import { syncCategoriesToMetaTitle } from './hooks/syncCategoriesToMetaTitle'
 import { syncHeroToMetaImage } from './hooks/syncHeroToMetaImage'
 import { syncTitleToMetaTitle } from './hooks/syncTitleToMetaTitle'
 import { syncTitleToSlug } from './hooks/syncTitleToSlug'
@@ -264,7 +265,7 @@ export const Posts: CollectionConfig<'posts'> = {
     },
   ],
   hooks: {
-    beforeChange: [syncHeroToMetaImage, syncTitleToMetaTitle, syncTitleToSlug],
+    beforeChange: [syncHeroToMetaImage, syncTitleToMetaTitle, syncCategoriesToMetaTitle, syncTitleToSlug],
     afterChange: [revalidatePost],
     afterRead: [populateAuthors],
     afterDelete: [revalidateDelete],


### PR DESCRIPTION
closes #78 
## What's Changed
We now have a hook that uses the Post Categories to construct an SEO title for the Post.