### PR TITLE
Keywords Feature

### DIFF
--- a/src/app/(frontend)/keywords/[name]/page.tsx
+++ b/src/app/(frontend)/keywords/[name]/page.tsx
@@ -35,9 +35,15 @@ export default async function Page({ params: paramsPromise }: Args) {
     collection: 'posts',
     depth: 1,
     limit: 12,
+    page: 1,
     overrideAccess: false,
     sort: '-publishedAt',
-    where: { keywords: { in: [keyword.id] } },
+    where: {
+      and: [
+        { keywords: { in: [keyword.id] } },
+        { _status: { equals: 'published' } },
+      ],
+    },
   })
 
   const basePath = `/keywords/${name}/page`
@@ -63,8 +69,8 @@ export default async function Page({ params: paramsPromise }: Args) {
       <CollectionArchive posts={posts.docs} />
 
       <div className="container">
-        {posts.totalPages > 1 && posts.page && (
-          <Pagination basePath={basePath} page={posts.page} totalPages={posts.totalPages} />
+        {posts.totalPages > 1 && (
+          <Pagination basePath={basePath} page={posts.page ?? 1} totalPages={posts.totalPages} />
         )}
       </div>
     </div>

--- a/src/app/(frontend)/keywords/[name]/page.tsx
+++ b/src/app/(frontend)/keywords/[name]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next/types'
 
+import { BackLink } from '@/components/ui/back-link'
 import { CollectionArchive } from '@/components/CollectionArchive'
 import { PageRange } from '@/components/PageRange'
 import { Pagination } from '@/components/Pagination'
@@ -47,6 +48,7 @@ export default async function Page({ params: paramsPromise }: Args) {
         <div className="prose dark:prose-invert max-w-none">
           <h1>{keyword.name}</h1>
         </div>
+        <BackLink />
       </div>
 
       <div className="container mb-8">

--- a/src/app/(frontend)/keywords/[name]/page.tsx
+++ b/src/app/(frontend)/keywords/[name]/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next/types'
+
+import { CollectionArchive } from '@/components/CollectionArchive'
+import { PageRange } from '@/components/PageRange'
+import { Pagination } from '@/components/Pagination'
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+import { notFound } from 'next/navigation'
+import React from 'react'
+
+export const revalidate = 600
+
+type Args = {
+  params: Promise<{
+    name: string
+  }>
+}
+
+export default async function Page({ params: paramsPromise }: Args) {
+  const { name } = await paramsPromise
+  const keywordName = name.replace(/-/g, ' ')
+  const payload = await getPayload({ config: configPromise })
+
+  const keywordResult = await payload.find({
+    collection: 'keywords',
+    limit: 1,
+    where: { name: { equals: keywordName } },
+  })
+
+  const keyword = keywordResult.docs?.[0]
+  if (!keyword) notFound()
+
+  const posts = await payload.find({
+    collection: 'posts',
+    depth: 1,
+    limit: 12,
+    overrideAccess: false,
+    sort: '-publishedAt',
+    where: { keywords: { in: [keyword.id] } },
+  })
+
+  const basePath = `/keywords/${name}/page`
+
+  return (
+    <div className="pt-24 pb-24">
+      <div className="container mb-16">
+        <div className="prose dark:prose-invert max-w-none">
+          <h1>{keyword.name}</h1>
+        </div>
+      </div>
+
+      <div className="container mb-8">
+        <PageRange
+          collection="posts"
+          currentPage={posts.page}
+          limit={12}
+          totalDocs={posts.totalDocs}
+        />
+      </div>
+
+      <CollectionArchive posts={posts.docs} />
+
+      <div className="container">
+        {posts.totalPages > 1 && posts.page && (
+          <Pagination basePath={basePath} page={posts.page} totalPages={posts.totalPages} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
+  const { name } = await paramsPromise
+  const keywordName = name.replace(/-/g, ' ')
+  return {
+    title: `Posts tagged: ${keywordName}`,
+  }
+}
+
+export async function generateStaticParams() {
+  const payload = await getPayload({ config: configPromise })
+
+  const keywords = await payload.find({
+    collection: 'keywords',
+    limit: 1000,
+    pagination: false,
+  })
+
+  return keywords.docs.map((kw) => ({
+    name: kw.name.replace(/\s+/g, '-'),
+  }))
+}

--- a/src/app/(frontend)/keywords/[name]/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/keywords/[name]/page/[pageNumber]/page.tsx
@@ -42,7 +42,12 @@ export default async function Page({ params: paramsPromise }: Args) {
     page: sanitizedPageNumber,
     overrideAccess: false,
     sort: '-publishedAt',
-    where: { keywords: { in: [keyword.id] } },
+    where: {
+      and: [
+        { keywords: { in: [keyword.id] } },
+        { _status: { equals: 'published' } },
+      ],
+    },
   })
 
   const basePath = `/keywords/${name}/page`

--- a/src/app/(frontend)/keywords/[name]/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/keywords/[name]/page/[pageNumber]/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from 'next/types'
+
+import { CollectionArchive } from '@/components/CollectionArchive'
+import { PageRange } from '@/components/PageRange'
+import { Pagination } from '@/components/Pagination'
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+import { notFound } from 'next/navigation'
+import React from 'react'
+
+export const revalidate = 600
+
+type Args = {
+  params: Promise<{
+    name: string
+    pageNumber: string
+  }>
+}
+
+export default async function Page({ params: paramsPromise }: Args) {
+  const { name, pageNumber } = await paramsPromise
+  const sanitizedPageNumber = Number(pageNumber)
+  if (!Number.isInteger(sanitizedPageNumber)) notFound()
+
+  const keywordName = name.replace(/-/g, ' ')
+  const payload = await getPayload({ config: configPromise })
+
+  const keywordResult = await payload.find({
+    collection: 'keywords',
+    limit: 1,
+    where: { name: { equals: keywordName } },
+  })
+
+  const keyword = keywordResult.docs?.[0]
+  if (!keyword) notFound()
+
+  const posts = await payload.find({
+    collection: 'posts',
+    depth: 1,
+    limit: 12,
+    page: sanitizedPageNumber,
+    overrideAccess: false,
+    sort: '-publishedAt',
+    where: { keywords: { in: [keyword.id] } },
+  })
+
+  const basePath = `/keywords/${name}/page`
+
+  return (
+    <div className="pt-24 pb-24">
+      <div className="container mb-16">
+        <div className="prose dark:prose-invert max-w-none">
+          <h1>{keyword.name}</h1>
+        </div>
+      </div>
+
+      <div className="container mb-8">
+        <PageRange
+          collection="posts"
+          currentPage={posts.page}
+          limit={12}
+          totalDocs={posts.totalDocs}
+        />
+      </div>
+
+      <CollectionArchive posts={posts.docs} />
+
+      <div className="container">
+        {posts.totalPages > 1 && posts.page && (
+          <Pagination basePath={basePath} page={posts.page} totalPages={posts.totalPages} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
+  const { name, pageNumber } = await paramsPromise
+  const keywordName = name.replace(/-/g, ' ')
+  return {
+    title: `Posts tagged: ${keywordName} — Page ${pageNumber}`,
+  }
+}
+
+export async function generateStaticParams() {
+  const payload = await getPayload({ config: configPromise })
+
+  const keywords = await payload.find({
+    collection: 'keywords',
+    limit: 1000,
+    pagination: false,
+  })
+
+  const params: { name: string; pageNumber: string }[] = []
+
+  for (const kw of keywords.docs) {
+    const { totalDocs } = await payload.count({
+      collection: 'posts',
+      overrideAccess: false,
+      where: { keywords: { in: [kw.id] } },
+    })
+
+    const totalPages = Math.ceil(totalDocs / 12)
+    const urlName = kw.name.replace(/\s+/g, '-')
+
+    for (let i = 1; i <= totalPages; i++) {
+      params.push({ name: urlName, pageNumber: String(i) })
+    }
+  }
+
+  return params
+}

--- a/src/app/(frontend)/keywords/[name]/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/keywords/[name]/page/[pageNumber]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next/types'
 
+import { BackLink } from '@/components/ui/back-link'
 import { CollectionArchive } from '@/components/CollectionArchive'
 import { PageRange } from '@/components/PageRange'
 import { Pagination } from '@/components/Pagination'
@@ -52,6 +53,7 @@ export default async function Page({ params: paramsPromise }: Args) {
         <div className="prose dark:prose-invert max-w-none">
           <h1>{keyword.name}</h1>
         </div>
+        <BackLink />
       </div>
 
       <div className="container mb-8">

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -104,6 +104,7 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
 
   const result = await payload.find({
     collection: 'posts',
+    depth: 1,
     draft,
     limit: 1,
     overrideAccess: draft,

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -52,12 +52,8 @@ export default async function Post({ params: paramsPromise }: Args) {
 
   if (!post) return <PayloadRedirects url={url} />
 
-  const keywordIds = (post.keywords ?? []).map((k) =>
-    typeof k === 'object' ? k.id : k,
-  )
-  const categoryIds = (post.categories ?? []).map((k) =>
-    typeof k === 'object' ? k.id : k,
-  )
+  const keywordIds = (post.keywords ?? []).map((k) => (typeof k === 'object' ? k.id : k))
+  const categoryIds = (post.categories ?? []).map((k) => (typeof k === 'object' ? k.id : k))
 
   const relatedPosts = await getRelatedPostsByKeywords({
     keywordIds,
@@ -77,15 +73,13 @@ export default async function Post({ params: paramsPromise }: Args) {
       <PostHero post={post} />
 
       <div className="flex flex-col items-center gap-4 pt-8">
-        <div className="container">
-          <RichText className="max-w-[48rem] mx-auto" data={post.content} enableGutter={false} />
-          {relatedPosts.length > 0 && (
-            <div className="mt-12 max-w-[52rem] mx-auto">
-              <h2 className="text-xl font-semibold mb-6">Related Posts</h2>
-              <RelatedPosts docs={relatedPosts} />
-            </div>
-          )}
-        </div>
+        <RichText className="max-w-[48rem] mx-auto" data={post.content} enableGutter={false} />
+        {relatedPosts.length > 0 && (
+          <section className="w-full">
+            <h2 className="text-xl font-semibold mb-6">Related Posts</h2>
+            <RelatedPosts docs={relatedPosts} />
+          </section>
+        )}
       </div>
     </article>
   )

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -55,11 +55,15 @@ export default async function Post({ params: paramsPromise }: Args) {
   const keywordIds = (post.keywords ?? []).map((k) =>
     typeof k === 'object' ? k.id : k,
   )
+  const categoryIds = (post.categories ?? []).map((k) =>
+    typeof k === 'object' ? k.id : k,
+  )
 
-  const relatedByKeywords =
-    keywordIds.length > 0
-      ? await getRelatedPostsByKeywords({ keywordIds, currentPostId: post.id })
-      : []
+  const relatedPosts = await getRelatedPostsByKeywords({
+    keywordIds,
+    categoryIds,
+    currentPostId: post.id,
+  })
 
   return (
     <article className="pt-16 pb-16">
@@ -75,10 +79,10 @@ export default async function Post({ params: paramsPromise }: Args) {
       <div className="flex flex-col items-center gap-4 pt-8">
         <div className="container">
           <RichText className="max-w-[48rem] mx-auto" data={post.content} enableGutter={false} />
-          {relatedByKeywords.length > 0 && (
+          {relatedPosts.length > 0 && (
             <div className="mt-12 max-w-[52rem] mx-auto">
               <h2 className="text-xl font-semibold mb-6">Related Posts</h2>
-              <RelatedPosts docs={relatedByKeywords} />
+              <RelatedPosts docs={relatedPosts} />
             </div>
           )}
         </div>

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -52,14 +52,17 @@ export default async function Post({ params: paramsPromise }: Args) {
 
   if (!post) return <PayloadRedirects url={url} />
 
+  const manualRelatedPosts = (post.relatedPosts ?? []).filter(
+    (r): r is Post => typeof r === 'object',
+  )
+
   const keywordIds = (post.keywords ?? []).map((k) => (typeof k === 'object' ? k.id : k))
   const categoryIds = (post.categories ?? []).map((k) => (typeof k === 'object' ? k.id : k))
 
-  const relatedPosts = await getRelatedPostsByKeywords({
-    keywordIds,
-    categoryIds,
-    currentPostId: post.id,
-  })
+  const relatedPosts =
+    manualRelatedPosts.length > 0
+      ? manualRelatedPosts
+      : await getRelatedPostsByKeywords({ keywordIds, categoryIds, currentPostId: post.id })
 
   return (
     <article className="pt-16 pb-16">
@@ -72,7 +75,7 @@ export default async function Post({ params: paramsPromise }: Args) {
 
       <PostHero post={post} />
 
-      <div className="flex flex-col items-center gap-4 pt-8">
+      <div className="flex flex-col items-center gap-4 px-8 py-6">
         <RichText className="max-w-[48rem] mx-auto" data={post.content} enableGutter={false} />
         {relatedPosts.length > 0 && (
           <section className="w-full">

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -12,6 +12,7 @@ import type { Post } from '@/payload-types'
 
 import { PostHero } from '@/heros/PostHero'
 import { generateMeta } from '@/utilities/generateMeta'
+import { getRelatedPostsByKeywords } from '@/utilities/getRelatedPostsByKeywords'
 import PageClient from './page.client'
 import { LivePreviewListener } from '@/components/LivePreviewListener'
 
@@ -51,6 +52,15 @@ export default async function Post({ params: paramsPromise }: Args) {
 
   if (!post) return <PayloadRedirects url={url} />
 
+  const keywordIds = (post.keywords ?? []).map((k) =>
+    typeof k === 'object' ? k.id : k,
+  )
+
+  const relatedByKeywords =
+    keywordIds.length > 0
+      ? await getRelatedPostsByKeywords({ keywordIds, currentPostId: post.id })
+      : []
+
   return (
     <article className="pt-16 pb-16">
       <PageClient />
@@ -65,11 +75,11 @@ export default async function Post({ params: paramsPromise }: Args) {
       <div className="flex flex-col items-center gap-4 pt-8">
         <div className="container">
           <RichText className="max-w-[48rem] mx-auto" data={post.content} enableGutter={false} />
-          {post.relatedPosts && post.relatedPosts.length > 0 && (
-            <RelatedPosts
-              className="mt-12 max-w-[52rem] lg:grid lg:grid-cols-subgrid col-start-1 col-span-3 grid-rows-[2fr]"
-              docs={post.relatedPosts.filter((post) => typeof post === 'object')}
-            />
+          {relatedByKeywords.length > 0 && (
+            <div className="mt-12 max-w-[52rem] mx-auto">
+              <h2 className="text-xl font-semibold mb-6">Related Posts</h2>
+              <RelatedPosts docs={relatedByKeywords} />
+            </div>
           )}
         </div>
       </div>

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -23,6 +23,7 @@ export default async function Page() {
       title: true,
       slug: true,
       categories: true,
+      keywords: true,
       meta: true,
     },
   })

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -35,6 +35,7 @@ import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0
 import { default as default_b49834c38af02a233bd8ffd68317c41f } from '@/collections/Posts/components/KeywordsInputField'
 import { default as default_af9113d48444c00bb4919c8ae754b46f } from '@/collections/Posts/components/KeywordFrequencyField'
 import { default as default_000ace4bf1f9ff748ac15c677b9ef3f5 } from '@/collections/Posts/components/PostSlugField'
+import { default as default_89f405e955f669bee627473ef93dbd1b } from '@/collections/Posts/components/SocialPreviewField'
 import { default as default_72de2780787708611145fd8a30acae54 } from '@/collections/Posts/components/DraftBroadcastButton'
 import { default as default_9a0786c1d342d6df4705248ae531b25d } from '@/collections/Posts/components/BroadcastCell'
 import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
@@ -87,6 +88,7 @@ export const importMap = {
   "@/collections/Posts/components/KeywordsInputField#default": default_b49834c38af02a233bd8ffd68317c41f,
   "@/collections/Posts/components/KeywordFrequencyField#default": default_af9113d48444c00bb4919c8ae754b46f,
   "@/collections/Posts/components/PostSlugField#default": default_000ace4bf1f9ff748ac15c677b9ef3f5,
+  "@/collections/Posts/components/SocialPreviewField#default": default_89f405e955f669bee627473ef93dbd1b,
   "@/collections/Posts/components/DraftBroadcastButton#default": default_72de2780787708611145fd8a30acae54,
   "@/collections/Posts/components/BroadcastCell#default": default_9a0786c1d342d6df4705248ae531b25d,
   "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -34,6 +34,8 @@ import { default as default_df7eb999ede7363ee297ab1263291c5c } from '@/collectio
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_000ace4bf1f9ff748ac15c677b9ef3f5 } from '@/collections/Posts/components/PostSlugField'
 import { default as default_72de2780787708611145fd8a30acae54 } from '@/collections/Posts/components/DraftBroadcastButton'
+import { default as default_b49834c38af02a233bd8ffd68317c41f } from '@/collections/Posts/components/KeywordsInputField'
+import { default as default_af9113d48444c00bb4919c8ae754b46f } from '@/collections/Posts/components/KeywordFrequencyField'
 import { default as default_9a0786c1d342d6df4705248ae531b25d } from '@/collections/Posts/components/BroadcastCell'
 import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
@@ -84,6 +86,8 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@/collections/Posts/components/PostSlugField#default": default_000ace4bf1f9ff748ac15c677b9ef3f5,
   "@/collections/Posts/components/DraftBroadcastButton#default": default_72de2780787708611145fd8a30acae54,
+  "@/collections/Posts/components/KeywordsInputField#default": default_b49834c38af02a233bd8ffd68317c41f,
+  "@/collections/Posts/components/KeywordFrequencyField#default": default_af9113d48444c00bb4919c8ae754b46f,
   "@/collections/Posts/components/BroadcastCell#default": default_9a0786c1d342d6df4705248ae531b25d,
   "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -32,10 +32,10 @@ import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 }
 import { SlugField as SlugField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
 import { default as default_df7eb999ede7363ee297ab1263291c5c } from '@/collections/Posts/components/PostTitleField'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { default as default_000ace4bf1f9ff748ac15c677b9ef3f5 } from '@/collections/Posts/components/PostSlugField'
-import { default as default_72de2780787708611145fd8a30acae54 } from '@/collections/Posts/components/DraftBroadcastButton'
 import { default as default_b49834c38af02a233bd8ffd68317c41f } from '@/collections/Posts/components/KeywordsInputField'
 import { default as default_af9113d48444c00bb4919c8ae754b46f } from '@/collections/Posts/components/KeywordFrequencyField'
+import { default as default_000ace4bf1f9ff748ac15c677b9ef3f5 } from '@/collections/Posts/components/PostSlugField'
+import { default as default_72de2780787708611145fd8a30acae54 } from '@/collections/Posts/components/DraftBroadcastButton'
 import { default as default_9a0786c1d342d6df4705248ae531b25d } from '@/collections/Posts/components/BroadcastCell'
 import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
@@ -84,10 +84,10 @@ export const importMap = {
   "@payloadcms/next/client#SlugField": SlugField_2b8867833a34864a02ddf429b0728a40,
   "@/collections/Posts/components/PostTitleField#default": default_df7eb999ede7363ee297ab1263291c5c,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/collections/Posts/components/PostSlugField#default": default_000ace4bf1f9ff748ac15c677b9ef3f5,
-  "@/collections/Posts/components/DraftBroadcastButton#default": default_72de2780787708611145fd8a30acae54,
   "@/collections/Posts/components/KeywordsInputField#default": default_b49834c38af02a233bd8ffd68317c41f,
   "@/collections/Posts/components/KeywordFrequencyField#default": default_af9113d48444c00bb4919c8ae754b46f,
+  "@/collections/Posts/components/PostSlugField#default": default_000ace4bf1f9ff748ac15c677b9ef3f5,
+  "@/collections/Posts/components/DraftBroadcastButton#default": default_72de2780787708611145fd8a30acae54,
   "@/collections/Posts/components/BroadcastCell#default": default_9a0786c1d342d6df4705248ae531b25d,
   "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,

--- a/src/blocks/RelatedPosts/Component.tsx
+++ b/src/blocks/RelatedPosts/Component.tsx
@@ -17,10 +17,10 @@ export const RelatedPosts: React.FC<RelatedPostsProps> = (props) => {
   const { className, docs, introContent } = props
 
   return (
-    <div className={clsx('lg:container', className)}>
+    <div className={clsx('w-full', className)}>
       {introContent && <RichText data={introContent} enableGutter={false} />}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8 items-stretch">
+      <div className="grid grid-cols-3 gap-4 md:gap-8">
         {docs?.map((doc, index) => {
           if (typeof doc === 'string') return null
 

--- a/src/collections/Keywords/index.ts
+++ b/src/collections/Keywords/index.ts
@@ -1,0 +1,35 @@
+import type { CollectionConfig } from 'payload'
+
+import { anyone } from '../../access/anyone'
+import { authenticated } from '../../access/authenticated'
+
+export const Keywords: CollectionConfig = {
+  slug: 'keywords',
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: anyone,
+    update: authenticated,
+  },
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      unique: true,
+    },
+  ],
+  hooks: {
+    beforeChange: [
+      ({ data }) => {
+        if (typeof data.name === 'string') {
+          data.name = data.name.trim().toLowerCase()
+        }
+        return data
+      },
+    ],
+  },
+}

--- a/src/collections/Posts/components/DraftBroadcastButton.tsx
+++ b/src/collections/Posts/components/DraftBroadcastButton.tsx
@@ -3,6 +3,7 @@
 import { useDocumentInfo } from '@payloadcms/ui'
 import { useState, useEffect } from 'react'
 
+import { SideBarSection, SideBarSubSection } from '@/components/ui/sidebarSections'
 import { fetchBroadcastsForPost, type BroadcastSummary } from '../utils/fetchBroadcastsForPost'
 
 type CreateBroadcastResponse = {
@@ -68,15 +69,9 @@ const DraftBroadcastButton: React.FC = () => {
   }
 
   return (
-    <div
-      style={{
-        padding: '12px 0',
-        borderTop: '1px solid var(--theme-border-color)',
-        marginTop: '8px',
-      }}
+    <SideBarSection
+      title="Broadcast"
     >
-      <h4 style={{ marginBottom: '10px', fontSize: '16px', fontWeight: 600 }}>Broadcast</h4>
-
       <div
         title={
           !isPublished
@@ -113,10 +108,7 @@ const DraftBroadcastButton: React.FC = () => {
       )}
 
       {existingBroadcasts.length > 0 && (
-        <div style={{ marginTop: '12px' }}>
-          <h5 style={{ fontSize: '14px', color: 'var(--theme-text-dim)', marginBottom: '4px' }}>
-            Sent in:
-          </h5>
+        <SideBarSubSection title="Sent in:" style={{ marginTop: '12px' }}>
           <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
             {existingBroadcasts.map((b) => (
               <li key={b.id} style={{ marginBottom: '4px', textDecoration: 'underline' }}>
@@ -136,9 +128,9 @@ const DraftBroadcastButton: React.FC = () => {
               </li>
             ))}
           </ul>
-        </div>
+        </SideBarSubSection>
       )}
-    </div>
+    </SideBarSection>
   )
 }
 

--- a/src/collections/Posts/components/KeywordFrequencyField.tsx
+++ b/src/collections/Posts/components/KeywordFrequencyField.tsx
@@ -4,9 +4,10 @@ import { useField } from '@payloadcms/ui'
 import { useEffect, useRef, useState } from 'react'
 
 import { extractLexicalText } from '@/utilities/extractLexicalText'
+import { SideBarSubSection } from '@/components/ui/sidebarSections'
 
 type KeywordEntry = {
-  id: string
+  id: string | number
   name: string
   count: number
 }
@@ -32,14 +33,15 @@ function getThreshold(count: number): ThresholdResult {
   return { color: '#f97316', label: 'High' }
 }
 
-function extractIds(fieldValue: unknown): string[] {
+function extractIds(fieldValue: unknown): (string | number)[] {
   if (!Array.isArray(fieldValue)) return []
   return fieldValue.flatMap((item) => {
     if (typeof item === 'string') return [item]
+    if (typeof item === 'number') return [item]
     if (typeof item === 'object' && item !== null) {
       const obj = item as Record<string, unknown>
       const id = obj.value ?? obj.id
-      if (typeof id === 'string') return [id]
+      if (typeof id === 'string' || typeof id === 'number') return [id]
     }
     return []
   })
@@ -50,7 +52,7 @@ const KeywordFrequencyField: React.FC = () => {
   const { value: keywordsRaw } = useField<unknown>({ path: 'keywords' })
 
   const [entries, setEntries] = useState<KeywordEntry[]>([])
-  const nameCache = useRef<Record<string, string>>({})
+  const nameCache = useRef<Record<string | number, string>>({})
 
   const keywordIds = extractIds(keywordsRaw)
 
@@ -65,9 +67,7 @@ const KeywordFrequencyField: React.FC = () => {
     const compute = async () => {
       if (uncached.length > 0) {
         try {
-          const res = await fetch(
-            `/api/keywords?where[id][in]=${uncached.join(',')}&limit=50`,
-          )
+          const res = await fetch(`/api/keywords?where[id][in]=${uncached.join(',')}&limit=50`)
           if (res.ok) {
             const data = (await res.json()) as { docs: Array<{ id: string; name: string }> }
             for (const kw of data.docs) {
@@ -101,20 +101,8 @@ const KeywordFrequencyField: React.FC = () => {
   if (!entries.length) return null
 
   return (
-    <div style={{ marginTop: '8px', marginBottom: '4px' }}>
-      <p
-        style={{
-          color: 'var(--theme-text-dim)',
-          fontSize: '11px',
-          fontWeight: 600,
-          letterSpacing: '0.05em',
-          marginBottom: '6px',
-          textTransform: 'uppercase',
-        }}
-      >
-        Keyword Frequency
-      </p>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+    <SideBarSubSection title="Keyword Frequency">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         {entries.map(({ id, name, count }) => {
           const { color, label } = getThreshold(count)
           return (
@@ -123,7 +111,7 @@ const KeywordFrequencyField: React.FC = () => {
               style={{
                 alignItems: 'center',
                 display: 'flex',
-                fontSize: '12px',
+                fontSize: '18px',
                 justifyContent: 'space-between',
               }}
             >
@@ -139,14 +127,13 @@ const KeywordFrequencyField: React.FC = () => {
                 {name}
               </span>
               <span style={{ color, flexShrink: 0, fontWeight: 600 }}>
-                {count}×{' '}
-                <span style={{ fontSize: '11px', fontWeight: 400 }}>{label}</span>
+                {count}× <span style={{ fontSize: '16px', fontWeight: 400 }}>{label}</span>
               </span>
             </div>
           )
         })}
       </div>
-    </div>
+    </SideBarSubSection>
   )
 }
 

--- a/src/collections/Posts/components/KeywordFrequencyField.tsx
+++ b/src/collections/Posts/components/KeywordFrequencyField.tsx
@@ -21,6 +21,14 @@ type ThresholdResult = {
   color: string
   backgroundColor: string
   label: string
+  tooltip: string
+}
+
+type PillWithTooltipProps = {
+  color: string
+  backgroundColor: string
+  label: string
+  tooltip: string
 }
 
 function escapeRegex(str: string): string {
@@ -29,12 +37,105 @@ function escapeRegex(str: string): string {
 
 function getThreshold(count: number): ThresholdResult {
   if (count === 0)
-    return { color: '#ffffff', backgroundColor: '#6b7280', label: 'Missing' }
+    return {
+      color: '#ffffff',
+      backgroundColor: '#6b7280',
+      label: 'Missing',
+      tooltip:
+        'No occurrences found in the post body. Add this keyword naturally to signal relevance to search engines.',
+    }
   if (count <= 2)
-    return { color: '#ffffff', backgroundColor: '#d97706', label: 'Low' }
+    return {
+      color: '#ffffff',
+      backgroundColor: '#d97706',
+      label: 'Low',
+      tooltip:
+        'Below the recommended range. Mention this keyword a few more times where it fits naturally.',
+    }
   if (count <= 5)
-    return { color: '#ffffff', backgroundColor: '#16a34a', label: 'Optimal' }
-  return { color: '#ffffff', backgroundColor: '#ea580c', label: 'High' }
+    return {
+      color: '#ffffff',
+      backgroundColor: '#16a34a',
+      label: 'Optimal',
+      tooltip:
+        'Ideal frequency. Search engines can clearly associate this post with the topic without over-optimization.',
+    }
+  return {
+    color: '#ffffff',
+    backgroundColor: '#ea580c',
+    label: 'High',
+    tooltip:
+      'May appear too often. Excessive repetition can look like keyword stuffing — consider reducing usage.',
+  }
+}
+
+const TOOLTIP_BG = '#1f2937'
+
+const PillWithTooltip: React.FC<PillWithTooltipProps> = ({
+  color,
+  backgroundColor,
+  label,
+  tooltip,
+}) => {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <span
+      style={{ display: 'inline-block', position: 'relative' }}
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+    >
+      {visible && (
+        <span
+          role="tooltip"
+          style={{
+            backgroundColor: TOOLTIP_BG,
+            borderRadius: '6px',
+            bottom: 'calc(100% + 8px)',
+            color: '#f9fafb',
+            fontSize: '16px',
+            fontWeight: 400,
+            lineHeight: 1.5,
+            padding: '8px 10px',
+            pointerEvents: 'none',
+            position: 'absolute',
+            right: 0,
+            width: '220px',
+            zIndex: 10,
+          }}
+        >
+          {tooltip}
+          <span
+            aria-hidden="true"
+            style={{
+              borderLeft: '5px solid transparent',
+              borderRight: '5px solid transparent',
+              borderTop: `5px solid ${TOOLTIP_BG}`,
+              bottom: '-5px',
+              height: 0,
+              position: 'absolute',
+              right: '10px',
+              width: 0,
+            }}
+          />
+        </span>
+      )}
+      <span
+        style={{
+          backgroundColor,
+          borderRadius: '9999px',
+          color,
+          cursor: 'default',
+          fontSize: '16px',
+          fontWeight: 700,
+          letterSpacing: '0.05em',
+          padding: '2px 8px',
+        }}
+      >
+        {label}
+      </span>
+    </span>
+  )
 }
 
 function extractIds(fieldValue: unknown): (string | number)[] {
@@ -108,7 +209,7 @@ const KeywordFrequencyField: React.FC = () => {
     <SideBarSubSection title="Keyword Frequency">
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         {entries.map(({ id, name, count }) => {
-          const { color, backgroundColor, label } = getThreshold(count)
+          const { color, backgroundColor, label, tooltip } = getThreshold(count)
           return (
             <div
               key={id}
@@ -132,19 +233,12 @@ const KeywordFrequencyField: React.FC = () => {
               </span>
               <span style={{ alignItems: 'center', display: 'flex', flexShrink: 0, gap: '6px' }}>
                 <span style={{ color: 'var(--theme-text-dim)', fontWeight: 600 }}>{count}×</span>
-                <span
-                  style={{
-                    backgroundColor,
-                    borderRadius: '9999px',
-                    color,
-                    fontSize: '16px',
-                    fontWeight: 700,
-                    letterSpacing: '0.05em',
-                    padding: '2px 8px',
-                  }}
-                >
-                  {label}
-                </span>
+                <PillWithTooltip
+                  color={color}
+                  backgroundColor={backgroundColor}
+                  label={label}
+                  tooltip={tooltip}
+                />
               </span>
             </div>
           )

--- a/src/collections/Posts/components/KeywordFrequencyField.tsx
+++ b/src/collections/Posts/components/KeywordFrequencyField.tsx
@@ -19,6 +19,7 @@ type LexicalData = {
 
 type ThresholdResult = {
   color: string
+  backgroundColor: string
   label: string
 }
 
@@ -27,10 +28,13 @@ function escapeRegex(str: string): string {
 }
 
 function getThreshold(count: number): ThresholdResult {
-  if (count === 0) return { color: 'var(--theme-text-dim)', label: 'Missing' }
-  if (count <= 2) return { color: '#f59e0b', label: 'Low' }
-  if (count <= 5) return { color: '#22c55e', label: 'Optimal' }
-  return { color: '#f97316', label: 'High' }
+  if (count === 0)
+    return { color: '#ffffff', backgroundColor: '#6b7280', label: 'Missing' }
+  if (count <= 2)
+    return { color: '#ffffff', backgroundColor: '#d97706', label: 'Low' }
+  if (count <= 5)
+    return { color: '#ffffff', backgroundColor: '#16a34a', label: 'Optimal' }
+  return { color: '#ffffff', backgroundColor: '#ea580c', label: 'High' }
 }
 
 function extractIds(fieldValue: unknown): (string | number)[] {
@@ -104,21 +108,21 @@ const KeywordFrequencyField: React.FC = () => {
     <SideBarSubSection title="Keyword Frequency">
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         {entries.map(({ id, name, count }) => {
-          const { color, label } = getThreshold(count)
+          const { color, backgroundColor, label } = getThreshold(count)
           return (
             <div
               key={id}
               style={{
                 alignItems: 'center',
                 display: 'flex',
-                fontSize: '18px',
+                fontSize: '16px',
                 justifyContent: 'space-between',
               }}
             >
               <span
                 style={{
                   color: 'var(--theme-text)',
-                  maxWidth: '60%',
+                  maxWidth: '55%',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
@@ -126,8 +130,21 @@ const KeywordFrequencyField: React.FC = () => {
               >
                 {name}
               </span>
-              <span style={{ color, flexShrink: 0, fontWeight: 600 }}>
-                {count}× <span style={{ fontSize: '16px', fontWeight: 400 }}>{label}</span>
+              <span style={{ alignItems: 'center', display: 'flex', flexShrink: 0, gap: '6px' }}>
+                <span style={{ color: 'var(--theme-text-dim)', fontWeight: 600 }}>{count}×</span>
+                <span
+                  style={{
+                    backgroundColor,
+                    borderRadius: '9999px',
+                    color,
+                    fontSize: '16px',
+                    fontWeight: 700,
+                    letterSpacing: '0.05em',
+                    padding: '2px 8px',
+                  }}
+                >
+                  {label}
+                </span>
               </span>
             </div>
           )

--- a/src/collections/Posts/components/KeywordFrequencyField.tsx
+++ b/src/collections/Posts/components/KeywordFrequencyField.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useField } from '@payloadcms/ui'
+import { useEffect, useRef, useState } from 'react'
+
+import { extractLexicalText } from '@/utilities/extractLexicalText'
+
+type KeywordEntry = {
+  id: string
+  name: string
+  count: number
+}
+
+type LexicalData = {
+  root: { text?: string; children?: unknown[]; [k: string]: unknown }
+  [k: string]: unknown
+}
+
+type ThresholdResult = {
+  color: string
+  label: string
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function getThreshold(count: number): ThresholdResult {
+  if (count === 0) return { color: 'var(--theme-text-dim)', label: 'Missing' }
+  if (count <= 2) return { color: '#f59e0b', label: 'Low' }
+  if (count <= 5) return { color: '#22c55e', label: 'Optimal' }
+  return { color: '#f97316', label: 'High' }
+}
+
+function extractIds(fieldValue: unknown): string[] {
+  if (!Array.isArray(fieldValue)) return []
+  return fieldValue.flatMap((item) => {
+    if (typeof item === 'string') return [item]
+    if (typeof item === 'object' && item !== null) {
+      const obj = item as Record<string, unknown>
+      const id = obj.value ?? obj.id
+      if (typeof id === 'string') return [id]
+    }
+    return []
+  })
+}
+
+const KeywordFrequencyField: React.FC = () => {
+  const { value: contentValue } = useField<LexicalData>({ path: 'content' })
+  const { value: keywordsRaw } = useField<unknown>({ path: 'keywords' })
+
+  const [entries, setEntries] = useState<KeywordEntry[]>([])
+  const nameCache = useRef<Record<string, string>>({})
+
+  const keywordIds = extractIds(keywordsRaw)
+
+  useEffect(() => {
+    if (!keywordIds.length) {
+      setEntries([])
+      return
+    }
+
+    const uncached = keywordIds.filter((id) => !nameCache.current[id])
+
+    const compute = async () => {
+      if (uncached.length > 0) {
+        try {
+          const res = await fetch(
+            `/api/keywords?where[id][in]=${uncached.join(',')}&limit=50`,
+          )
+          if (res.ok) {
+            const data = (await res.json()) as { docs: Array<{ id: string; name: string }> }
+            for (const kw of data.docs) {
+              nameCache.current[kw.id] = kw.name
+            }
+          }
+        } catch {
+          // non-critical — fall back to showing ID
+        }
+      }
+
+      const bodyText = contentValue?.root
+        ? extractLexicalText(contentValue.root as Parameters<typeof extractLexicalText>[0])
+        : ''
+
+      setEntries(
+        keywordIds.map((id) => {
+          const name = nameCache.current[id] ?? id
+          const regex = new RegExp(`\\b${escapeRegex(name)}\\b`, 'gi')
+          const count = (bodyText.match(regex) ?? []).length
+          return { id, name, count }
+        }),
+      )
+    }
+
+    void compute()
+    // keywordIds is derived inline so we stringify it to detect real changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(keywordIds), contentValue])
+
+  if (!entries.length) return null
+
+  return (
+    <div style={{ marginTop: '8px', marginBottom: '4px' }}>
+      <p
+        style={{
+          color: 'var(--theme-text-dim)',
+          fontSize: '11px',
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+          marginBottom: '6px',
+          textTransform: 'uppercase',
+        }}
+      >
+        Keyword Frequency
+      </p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {entries.map(({ id, name, count }) => {
+          const { color, label } = getThreshold(count)
+          return (
+            <div
+              key={id}
+              style={{
+                alignItems: 'center',
+                display: 'flex',
+                fontSize: '12px',
+                justifyContent: 'space-between',
+              }}
+            >
+              <span
+                style={{
+                  color: 'var(--theme-text)',
+                  maxWidth: '60%',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {name}
+              </span>
+              <span style={{ color, flexShrink: 0, fontWeight: 600 }}>
+                {count}×{' '}
+                <span style={{ fontSize: '11px', fontWeight: 400 }}>{label}</span>
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default KeywordFrequencyField

--- a/src/collections/Posts/components/KeywordFrequencyField.tsx
+++ b/src/collections/Posts/components/KeywordFrequencyField.tsx
@@ -206,8 +206,18 @@ const KeywordFrequencyField: React.FC = () => {
   if (!entries.length) return null
 
   return (
-    <SideBarSubSection title="Keyword Frequency">
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+    <SideBarSubSection>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+          marginBottom: '2rem',
+          paddingBottom: '1rem',
+          borderBottom: '1px solid var(--theme-border-color)',
+        }}
+      >
+        <label>Keyword Frequency</label>
         {entries.map(({ id, name, count }) => {
           const { color, backgroundColor, label, tooltip } = getThreshold(count)
           return (
@@ -229,7 +239,7 @@ const KeywordFrequencyField: React.FC = () => {
                   whiteSpace: 'nowrap',
                 }}
               >
-                {name}
+                - {name}
               </span>
               <span style={{ alignItems: 'center', display: 'flex', flexShrink: 0, gap: '6px' }}>
                 <span style={{ color: 'var(--theme-text-dim)', fontWeight: 600 }}>{count}×</span>

--- a/src/collections/Posts/components/KeywordsInputField.tsx
+++ b/src/collections/Posts/components/KeywordsInputField.tsx
@@ -1,0 +1,313 @@
+'use client'
+
+import { useField } from '@payloadcms/ui'
+import { useEffect, useRef, useState } from 'react'
+
+type KeywordDoc = {
+  id: string | number
+  name: string
+}
+
+type KeywordsApiResponse = {
+  docs: KeywordDoc[]
+}
+
+type KeywordCreateApiResponse = {
+  doc: KeywordDoc
+}
+
+const KeywordsInputField: React.FC = () => {
+  const { value: fieldValue, setValue } = useField<(string | number)[]>({ path: 'keywords' })
+
+  const [inputText, setInputText] = useState('')
+  const [suggestions, setSuggestions] = useState<KeywordDoc[]>([])
+  const [highlightIndex, setHighlightIndex] = useState(0)
+  const [resolvedNames, setResolvedNames] = useState<Record<string | number, string>>({})
+  const [isCreating, setIsCreating] = useState(false)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const currentIds = fieldValue ?? []
+
+  // Resolve keyword names for display when existing IDs are loaded
+  useEffect(() => {
+    const missingIds = currentIds.filter((id) => !(id in resolvedNames))
+    if (!missingIds.length) return
+
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/keywords?where[id][in]=${missingIds.join(',')}&limit=50&depth=0`,
+        )
+        if (!res.ok) return
+        const data = (await res.json()) as KeywordsApiResponse
+        setResolvedNames((prev) => {
+          const next = { ...prev }
+          for (const kw of data.docs) next[kw.id] = kw.name
+          return next
+        })
+      } catch {
+        // non-critical — chips fall back to showing the raw ID
+      }
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fieldValue])
+
+  // Debounced autocomplete suggestions
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+
+    const trimmed = inputText.trim()
+    if (!trimmed) {
+      setSuggestions([])
+      setHighlightIndex(0)
+      return
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/keywords?where[name][like]=${encodeURIComponent(trimmed)}&limit=10&depth=0`,
+        )
+        if (!res.ok) return
+        const data = (await res.json()) as KeywordsApiResponse
+        setSuggestions(data.docs.filter((kw) => !currentIds.includes(kw.id)))
+        setHighlightIndex(0)
+      } catch {
+        // non-critical
+      }
+    }, 150)
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputText])
+
+  const addKeyword = (id: string | number, name: string) => {
+    if (!currentIds.includes(id)) setValue([...currentIds, id])
+    setResolvedNames((prev) => ({ ...prev, [id]: name }))
+    setInputText('')
+    setSuggestions([])
+    setHighlightIndex(0)
+  }
+
+  const createOrFindKeyword = async (text: string): Promise<void> => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+
+    // Exact match already in suggestions — no API create needed
+    const exact = suggestions.find((s) => s.name.toLowerCase() === trimmed.toLowerCase())
+    if (exact) {
+      addKeyword(exact.id, exact.name)
+      return
+    }
+
+    setIsCreating(true)
+    try {
+      const createRes = await fetch('/api/keywords', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed }),
+      })
+
+      if (createRes.ok) {
+        const data = (await createRes.json()) as KeywordCreateApiResponse
+        addKeyword(data.doc.id, data.doc.name)
+        return
+      }
+
+      // Creation failed (likely a duplicate) — look it up
+      const findRes = await fetch(
+        `/api/keywords?where[name][equals]=${encodeURIComponent(trimmed)}&limit=1&depth=0`,
+      )
+      if (findRes.ok) {
+        const data = (await findRes.json()) as KeywordsApiResponse
+        const found = data.docs[0]
+        if (found) addKeyword(found.id, found.name)
+      }
+    } catch {
+      // non-critical
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const removeKeyword = (id: string | number) => {
+    setValue(currentIds.filter((existing) => existing !== id))
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'Tab':
+        if (suggestions.length > 0) {
+          e.preventDefault()
+          addKeyword(suggestions[highlightIndex].id, suggestions[highlightIndex].name)
+        }
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (suggestions.length > 0) {
+          addKeyword(suggestions[highlightIndex].id, suggestions[highlightIndex].name)
+        } else if (inputText.trim()) {
+          void createOrFindKeyword(inputText)
+        }
+        break
+      case 'ArrowDown':
+        e.preventDefault()
+        setHighlightIndex((i) => Math.min(i + 1, suggestions.length - 1))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setHighlightIndex((i) => Math.max(i - 1, 0))
+        break
+      case ',':
+        e.preventDefault()
+        if (inputText.trim()) void createOrFindKeyword(inputText)
+        break
+      case 'Escape':
+        setSuggestions([])
+        setHighlightIndex(0)
+        break
+      case 'Backspace':
+        if (!inputText && currentIds.length > 0) {
+          removeKeyword(currentIds[currentIds.length - 1])
+        }
+        break
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <label
+        style={{
+          color: 'var(--theme-text)',
+          display: 'block',
+          fontSize: '13px',
+          fontWeight: 600,
+        }}
+      >
+        Keywords
+      </label>
+
+      {/* Chips + text input */}
+      <div
+        onClick={() => inputRef.current?.focus()}
+        style={{
+          background: 'var(--theme-input-bg, var(--theme-elevation-100))',
+          border: '1px solid var(--theme-border-color)',
+          borderRadius: '4px',
+          cursor: 'text',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '4px',
+          minHeight: '38px',
+          padding: '4px 8px',
+        }}
+      >
+        {currentIds.map((id) => (
+          <span
+            key={id}
+            style={{
+              alignItems: 'center',
+              background: 'var(--theme-elevation-200)',
+              borderRadius: '3px',
+              color: 'var(--theme-text)',
+              display: 'inline-flex',
+              fontSize: '12px',
+              gap: '4px',
+              padding: '2px 6px',
+            }}
+          >
+            {resolvedNames[id] ?? String(id)}
+            <button
+              aria-label={`Remove ${resolvedNames[id] ?? id}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                removeKeyword(id)
+              }}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--theme-text-dim)',
+                cursor: 'pointer',
+                fontSize: '14px',
+                lineHeight: 1,
+                padding: '0 2px',
+              }}
+              type="button"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+
+        <input
+          ref={inputRef}
+          disabled={isCreating}
+          onBlur={() => setTimeout(() => setSuggestions([]), 150)}
+          onChange={(e) => setInputText(e.target.value.toLowerCase())}
+          onKeyDown={handleKeyDown}
+          placeholder={currentIds.length === 0 ? 'Add a keyword…' : ''}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--theme-text)',
+            flex: '1 1 80px',
+            fontSize: '13px',
+            minWidth: '80px',
+            outline: 'none',
+            padding: '2px 4px',
+          }}
+          type="text"
+          value={inputText}
+        />
+      </div>
+
+      {/* Autocomplete dropdown */}
+      {suggestions.length > 0 && (
+        <ul
+          style={{
+            background: 'var(--theme-elevation-0)',
+            border: '1px solid var(--theme-border-color)',
+            borderRadius: '4px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            listStyle: 'none',
+            margin: 0,
+            padding: '4px 0',
+            zIndex: 100,
+          }}
+        >
+          {suggestions.map((kw, i) => (
+            <li
+              key={kw.id}
+              onMouseDown={(e) => {
+                // Prevent input blur before the keyword is added
+                e.preventDefault()
+                addKeyword(kw.id, kw.name)
+              }}
+              onMouseEnter={() => setHighlightIndex(i)}
+              style={{
+                background:
+                  i === highlightIndex ? 'var(--theme-elevation-100)' : 'transparent',
+                color: 'var(--theme-text)',
+                cursor: 'pointer',
+                fontSize: '13px',
+                padding: '6px 12px',
+              }}
+            >
+              {kw.name}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p style={{ color: 'var(--theme-text-dim)', fontSize: '11px', margin: 0 }}>
+        Separate keywords by commas.
+      </p>
+    </div>
+  )
+}
+
+export default KeywordsInputField

--- a/src/collections/Posts/components/KeywordsInputField.tsx
+++ b/src/collections/Posts/components/KeywordsInputField.tsx
@@ -181,8 +181,9 @@ const KeywordsInputField: React.FC = () => {
   }
 
   return (
-    <SideBarSection title="Keywords">
+    <SideBarSection>
       {/* Chips + text input */}
+      <label>Keywords</label>
       <div
         onClick={() => inputRef.current?.focus()}
         style={{

--- a/src/collections/Posts/components/KeywordsInputField.tsx
+++ b/src/collections/Posts/components/KeywordsInputField.tsx
@@ -3,6 +3,8 @@
 import { useField } from '@payloadcms/ui'
 import { useEffect, useRef, useState } from 'react'
 
+import { SideBarSection } from '@/components/ui/sidebarSections'
+
 type KeywordDoc = {
   id: string | number
   name: string
@@ -179,18 +181,7 @@ const KeywordsInputField: React.FC = () => {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-      <label
-        style={{
-          color: 'var(--theme-text)',
-          display: 'block',
-          fontSize: '13px',
-          fontWeight: 600,
-        }}
-      >
-        Keywords
-      </label>
-
+    <SideBarSection title="Keywords">
       {/* Chips + text input */}
       <div
         onClick={() => inputRef.current?.focus()}
@@ -215,7 +206,7 @@ const KeywordsInputField: React.FC = () => {
               borderRadius: '3px',
               color: 'var(--theme-text)',
               display: 'inline-flex',
-              fontSize: '12px',
+              fontSize: '16px',
               gap: '4px',
               padding: '2px 6px',
             }}
@@ -232,7 +223,7 @@ const KeywordsInputField: React.FC = () => {
                 border: 'none',
                 color: 'var(--theme-text-dim)',
                 cursor: 'pointer',
-                fontSize: '14px',
+                fontSize: '16px',
                 lineHeight: 1,
                 padding: '0 2px',
               }}
@@ -289,8 +280,7 @@ const KeywordsInputField: React.FC = () => {
               }}
               onMouseEnter={() => setHighlightIndex(i)}
               style={{
-                background:
-                  i === highlightIndex ? 'var(--theme-elevation-100)' : 'transparent',
+                background: i === highlightIndex ? 'var(--theme-elevation-100)' : 'transparent',
                 color: 'var(--theme-text)',
                 cursor: 'pointer',
                 fontSize: '13px',
@@ -302,11 +292,10 @@ const KeywordsInputField: React.FC = () => {
           ))}
         </ul>
       )}
-
-      <p style={{ color: 'var(--theme-text-dim)', fontSize: '11px', margin: 0 }}>
+      <label style={{ color: 'var(--theme-text-dim)', fontSize: '14px', margin: '0 0 8px' }}>
         Separate keywords by commas.
-      </p>
-    </div>
+      </label>
+    </SideBarSection>
   )
 }
 

--- a/src/collections/Posts/components/SocialPreviewField.tsx
+++ b/src/collections/Posts/components/SocialPreviewField.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useField } from '@payloadcms/ui'
+import Image from 'next/image'
 import { useEffect, useState } from 'react'
 
 import { getMediaUrl } from '@/utilities/getMediaUrl'
@@ -82,14 +83,14 @@ const SocialPreviewField: React.FC = () => {
           }}
         >
           {imageUrl ? (
-            <img
+            <Image
               alt={title || 'preview'}
               src={imageUrl}
+              fill
+              unoptimized
               style={{
-                height: '100%',
                 objectFit: 'cover',
                 objectPosition: 'center',
-                width: '100%',
               }}
             />
           ) : (

--- a/src/collections/Posts/components/SocialPreviewField.tsx
+++ b/src/collections/Posts/components/SocialPreviewField.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { useField } from '@payloadcms/ui'
+import { useEffect, useState } from 'react'
+
+import { getMediaUrl } from '@/utilities/getMediaUrl'
+
+type MediaDoc = {
+  id?: string | number
+  url?: string | null
+  alt?: string | null
+  updatedAt?: string | null
+}
+
+const SocialPreviewField: React.FC = () => {
+  const { value: titleValue } = useField<string>({ path: 'meta.title' })
+  const { value: descValue } = useField<string>({ path: 'meta.description' })
+  const { value: imageValue } = useField<MediaDoc | string | number | null>({
+    path: 'meta.image',
+  })
+  const { value: slugValue } = useField<string>({ path: 'slug' })
+
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!imageValue) {
+      setImageUrl(null)
+      return
+    }
+
+    if (typeof imageValue === 'object' && imageValue !== null && 'url' in imageValue) {
+      setImageUrl(getMediaUrl(imageValue.url, imageValue.updatedAt) || null)
+      return
+    }
+
+    const id = typeof imageValue === 'string' || typeof imageValue === 'number' ? imageValue : null
+    if (!id) return
+
+    void fetch(`/api/media/${id}?depth=0`)
+      .then((r) => r.json())
+      .then((doc: MediaDoc) => {
+        setImageUrl(getMediaUrl(doc.url, doc.updatedAt) || null)
+      })
+      .catch(() => {})
+  }, [imageValue])
+
+  const domain = typeof window !== 'undefined' ? window.location.hostname : 'your-site.com'
+  const title = titleValue ?? ''
+  const description = descValue ?? ''
+  const slug = slugValue ?? ''
+
+  return (
+    <div style={{ marginBottom: '16px' }}>
+      <p
+        style={{
+          color: 'var(--theme-text-dim)',
+          fontSize: '11px',
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+          marginBottom: '10px',
+          textTransform: 'uppercase',
+        }}
+      >
+        Social / Link Preview
+      </p>
+
+      <div
+        style={{
+          border: '1px solid var(--theme-border-color)',
+          borderRadius: '14px',
+          maxWidth: '380px',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Hero image */}
+        <div
+          style={{
+            aspectRatio: '1.91 / 1',
+            background: 'var(--theme-elevation-100)',
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
+          {imageUrl ? (
+            <img
+              alt={title || 'preview'}
+              src={imageUrl}
+              style={{
+                height: '100%',
+                objectFit: 'cover',
+                objectPosition: 'center',
+                width: '100%',
+              }}
+            />
+          ) : (
+            <div
+              style={{
+                alignItems: 'center',
+                color: 'var(--theme-text-dim)',
+                display: 'flex',
+                fontSize: '12px',
+                height: '100%',
+                justifyContent: 'center',
+              }}
+            >
+              No meta image set
+            </div>
+          )}
+        </div>
+
+        {/* Text */}
+        <div
+          style={{
+            background: 'var(--theme-elevation-50, var(--theme-elevation-100))',
+            borderTop: '1px solid var(--theme-border-color)',
+            padding: '10px 14px 12px',
+          }}
+        >
+          <p
+            style={{
+              color: 'var(--theme-text-dim)',
+              fontSize: '11px',
+              letterSpacing: '0.02em',
+              marginBottom: '3px',
+              textTransform: 'uppercase',
+            }}
+          >
+            {domain}
+            {slug ? ` · /posts/${slug}` : ''}
+          </p>
+
+          {title && (
+            <p
+              style={
+                {
+                  color: 'var(--theme-text)',
+                  display: '-webkit-box',
+                  fontSize: '14px',
+                  fontWeight: 700,
+                  lineHeight: 1.3,
+                  marginBottom: description ? '3px' : 0,
+                  overflow: 'hidden',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 2,
+                } as React.CSSProperties
+              }
+            >
+              {title}
+            </p>
+          )}
+
+          {description && (
+            <p
+              style={
+                {
+                  color: 'var(--theme-text-dim)',
+                  display: '-webkit-box',
+                  fontSize: '12px',
+                  lineHeight: 1.4,
+                  overflow: 'hidden',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 2,
+                } as React.CSSProperties
+              }
+            >
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SocialPreviewField

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -88,6 +88,15 @@ export const Posts: CollectionConfig<'posts'> = {
         {
           fields: [
             {
+              name: 'categories',
+              type: 'relationship',
+              admin: {
+                position: 'sidebar',
+              },
+              hasMany: true,
+              relationTo: 'categories',
+            },
+            {
               name: 'heroImage',
               type: 'upload',
               relationTo: 'media',
@@ -110,24 +119,39 @@ export const Posts: CollectionConfig<'posts'> = {
               label: false,
               required: true,
             },
+            {
+              name: 'keywords',
+              type: 'relationship',
+              relationTo: 'keywords',
+              hasMany: true,
+              admin: {
+                position: 'sidebar',
+                components: {
+                  Field: '@/collections/Posts/components/KeywordsInputField',
+                },
+              },
+            },
+            {
+              name: 'keywordFrequency',
+              type: 'ui',
+              admin: {
+                position: 'sidebar',
+                components: {
+                  Field: '@/collections/Posts/components/KeywordFrequencyField',
+                },
+              },
+            },
           ],
           label: 'Content',
         },
         {
           fields: [
             {
-              name: 'categories',
-              type: 'relationship',
-              admin: {
-                position: 'sidebar',
-              },
-              hasMany: true,
-              relationTo: 'categories',
-            },
-            {
               name: 'relatedPosts',
               type: 'relationship',
               admin: {
+                description:
+                  'Manually select related posts. If left empty, related posts are chosen automatically by keyword and category.',
                 position: 'sidebar',
               },
               filterOptions: ({ id }) => {
@@ -249,28 +273,6 @@ export const Posts: CollectionConfig<'posts'> = {
         position: 'sidebar',
         components: {
           Field: '@/collections/Posts/components/DraftBroadcastButton',
-        },
-      },
-    },
-    {
-      name: 'keywords',
-      type: 'relationship',
-      relationTo: 'keywords',
-      hasMany: true,
-      admin: {
-        position: 'sidebar',
-        components: {
-          Field: '@/collections/Posts/components/KeywordsInputField',
-        },
-      },
-    },
-    {
-      name: 'keywordFrequency',
-      type: 'ui',
-      admin: {
-        position: 'sidebar',
-        components: {
-          Field: '@/collections/Posts/components/KeywordFrequencyField',
         },
       },
     },

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -253,6 +253,28 @@ export const Posts: CollectionConfig<'posts'> = {
       },
     },
     {
+      name: 'keywords',
+      type: 'relationship',
+      relationTo: 'keywords',
+      hasMany: true,
+      admin: {
+        position: 'sidebar',
+        components: {
+          Field: '@/collections/Posts/components/KeywordsInputField',
+        },
+      },
+    },
+    {
+      name: 'keywordFrequency',
+      type: 'ui',
+      admin: {
+        position: 'sidebar',
+        components: {
+          Field: '@/collections/Posts/components/KeywordFrequencyField',
+        },
+      },
+    },
+    {
       name: 'broadcasts',
       type: 'join',
       collection: 'broadcasts',

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -257,6 +257,15 @@ export const Posts: CollectionConfig<'posts'> = {
               titlePath: 'meta.title',
               descriptionPath: 'meta.description',
             }),
+            {
+              name: 'socialPreview',
+              type: 'ui',
+              admin: {
+                components: {
+                  Field: '@/collections/Posts/components/SocialPreviewField',
+                },
+              },
+            },
           ],
         },
         {

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -48,6 +48,7 @@ export const Posts: CollectionConfig<'posts'> = {
     title: true,
     slug: true,
     categories: true,
+    keywords: true,
     meta: {
       image: true,
       description: true,

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -145,6 +145,7 @@ export const Posts: CollectionConfig<'posts'> = {
               name: 'relatedPosts',
               type: 'relationship',
               admin: {
+                sortOptions: '-createdAt',
                 description:
                   'Manually select related posts. If left empty, related posts are chosen automatically by keyword and category.',
                 position: 'sidebar',

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -141,11 +141,6 @@ export const Posts: CollectionConfig<'posts'> = {
                 },
               },
             },
-          ],
-          label: 'Content',
-        },
-        {
-          fields: [
             {
               name: 'relatedPosts',
               type: 'relationship',
@@ -164,8 +159,76 @@ export const Posts: CollectionConfig<'posts'> = {
               hasMany: true,
               relationTo: 'posts',
             },
+            {
+              name: 'authors',
+              type: 'relationship',
+              admin: {
+                position: 'sidebar',
+              },
+              hasMany: true,
+              relationTo: 'users',
+            },
+            // This field is only used to populate the user data via the `populateAuthors` hook
+            // This is because the `user` collection has access control locked to protect user privacy
+            // GraphQL will also not return mutated user data that differs from the underlying schema
+            {
+              name: 'populatedAuthors',
+              type: 'array',
+              access: {
+                update: () => false,
+              },
+              admin: {
+                disabled: true,
+                readOnly: true,
+              },
+              fields: [
+                {
+                  name: 'id',
+                  type: 'text',
+                },
+                {
+                  name: 'name',
+                  type: 'text',
+                },
+              ],
+            },
+            slugField({
+              overrides: (field) => {
+                const slugTextField = field.fields[1] as TextField
+                slugTextField.admin = {
+                  ...slugTextField.admin,
+                  components: {
+                    Field: {
+                      clientProps: { useAsSlug: 'title' },
+                      path: '@/collections/Posts/components/PostSlugField',
+                    },
+                  },
+                }
+                return field
+              },
+            }),
+            {
+              name: 'publishedAt',
+              type: 'date',
+              admin: {
+                date: {
+                  pickerAppearance: 'dayAndTime',
+                },
+                position: 'sidebar',
+              },
+              hooks: {
+                beforeChange: [
+                  ({ siblingData, value }) => {
+                    if (siblingData._status === 'published' && !value) {
+                      return new Date()
+                    }
+                    return value
+                  },
+                ],
+              },
+            },
           ],
-          label: 'Meta',
+          label: 'Content',
         },
         {
           name: 'meta',
@@ -196,97 +259,34 @@ export const Posts: CollectionConfig<'posts'> = {
             }),
           ],
         },
-      ],
-    },
-    {
-      name: 'publishedAt',
-      type: 'date',
-      admin: {
-        date: {
-          pickerAppearance: 'dayAndTime',
-        },
-        position: 'sidebar',
-      },
-      hooks: {
-        beforeChange: [
-          ({ siblingData, value }) => {
-            if (siblingData._status === 'published' && !value) {
-              return new Date()
-            }
-            return value
-          },
-        ],
-      },
-    },
-    {
-      name: 'authors',
-      type: 'relationship',
-      admin: {
-        position: 'sidebar',
-      },
-      hasMany: true,
-      relationTo: 'users',
-    },
-    // This field is only used to populate the user data via the `populateAuthors` hook
-    // This is because the `user` collection has access control locked to protect user privacy
-    // GraphQL will also not return mutated user data that differs from the underlying schema
-    {
-      name: 'populatedAuthors',
-      type: 'array',
-      access: {
-        update: () => false,
-      },
-      admin: {
-        disabled: true,
-        readOnly: true,
-      },
-      fields: [
         {
-          name: 'id',
-          type: 'text',
-        },
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    slugField({
-      overrides: (field) => {
-        const slugTextField = field.fields[1] as TextField
-        slugTextField.admin = {
-          ...slugTextField.admin,
-          components: {
-            Field: {
-              clientProps: { useAsSlug: 'title' },
-              path: '@/collections/Posts/components/PostSlugField',
+          fields: [
+            {
+              name: 'draftBroadcastButton',
+              type: 'ui',
+              admin: {
+                position: 'sidebar',
+                components: {
+                  Field: '@/collections/Posts/components/DraftBroadcastButton',
+                },
+              },
             },
-          },
-        }
-        return field
-      },
-    }),
-    {
-      name: 'draftBroadcastButton',
-      type: 'ui',
-      admin: {
-        position: 'sidebar',
-        components: {
-          Field: '@/collections/Posts/components/DraftBroadcastButton',
+            {
+              name: 'broadcasts',
+              type: 'join',
+              collection: 'broadcasts',
+              on: 'posts',
+              admin: {
+                condition: () => false,
+                components: {
+                  Cell: '@/collections/Posts/components/BroadcastCell',
+                },
+              },
+            },
+          ],
+          label: 'Broadcast',
         },
-      },
-    },
-    {
-      name: 'broadcasts',
-      type: 'join',
-      collection: 'broadcasts',
-      on: 'posts',
-      admin: {
-        condition: () => false,
-        components: {
-          Cell: '@/collections/Posts/components/BroadcastCell',
-        },
-      },
+      ],
     },
   ],
   hooks: {

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -288,7 +288,13 @@ export const Posts: CollectionConfig<'posts'> = {
     },
   ],
   hooks: {
-    beforeChange: [syncHeroToMetaImage, syncTitleToMetaTitle, syncCategoriesToMetaTitle, syncContentToMetaDescription, syncTitleToSlug],
+    beforeChange: [
+      syncHeroToMetaImage,
+      syncTitleToMetaTitle,
+      syncCategoriesToMetaTitle,
+      syncContentToMetaDescription,
+      syncTitleToSlug,
+    ],
     afterChange: [revalidatePost],
     afterRead: [populateAuthors],
     afterDelete: [revalidateDelete],

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -37,9 +37,15 @@ export const Card: React.FC<{
       )}
       ref={card.ref}
     >
-      <div className="relative w-full ">
-        {!metaImage && <div className="">No image</div>}
-        {metaImage && typeof metaImage !== 'string' && <Media resource={metaImage} size="33vw" />}
+      <div className="relative w-full aspect-video overflow-hidden">
+        {!metaImage && <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">No image</div>}
+        {metaImage && typeof metaImage !== 'string' && (
+          <Media
+            resource={metaImage}
+            size="33vw"
+            imgClassName="absolute inset-0 w-full h-full object-cover object-center"
+          />
+        )}
       </div>
       <div className="p-4">
         {showCategories && hasCategories && (

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -7,8 +7,9 @@ import React, { Fragment } from 'react'
 import type { Post } from '@/payload-types'
 
 import { Media } from '@/components/Media'
+import { KeywordPill } from '@/components/ui/keyword-pill'
 
-export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title'>
+export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title' | 'keywords'>
 
 export const Card: React.FC<{
   alignItems?: 'center'
@@ -21,10 +22,11 @@ export const Card: React.FC<{
   const { card, link } = useClickableCard({})
   const { className, doc, relationTo, showCategories, title: titleFromProps } = props
 
-  const { slug, categories, meta, title } = doc || {}
+  const { slug, categories, keywords, meta, title } = doc || {}
   const { description, image: metaImage } = meta || {}
 
   const hasCategories = categories && Array.isArray(categories) && categories.length > 0
+  const hasKeywords = keywords && Array.isArray(keywords) && keywords.length > 0
   const titleToUse = titleFromProps || title
   const sanitizedDescription = description?.replace(/\s/g, ' ') // replace non-breaking space with white space
   const href = `/${relationTo}/${slug}`
@@ -84,6 +86,16 @@ export const Card: React.FC<{
           </div>
         )}
         {description && <div className="mt-2">{description && <p>{sanitizedDescription}</p>}</div>}
+        {hasKeywords && (
+          <div
+            className="flex flex-wrap gap-1.5 mt-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {keywords!.map((kw) =>
+              typeof kw === 'object' ? <KeywordPill key={kw.id} keyword={kw} /> : null,
+            )}
+          </div>
+        )}
       </div>
     </article>
   )

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/pagination'
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 export const Pagination: React.FC<{
   basePath?: string
@@ -26,6 +26,11 @@ export const Pagination: React.FC<{
 
   const hasExtraPrevPages = page - 1 > 1
   const hasExtraNextPages = page + 1 < totalPages
+
+  useEffect(() => {
+    if (hasNextPage) router.prefetch(`${basePath}/${page + 1}`)
+    if (hasPrevPage) router.prefetch(`${basePath}/${page - 1}`)
+  }, [basePath, page, hasNextPage, hasPrevPage, router])
 
   return (
     <div className={cn('my-12', className)}>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -13,13 +13,14 @@ import { useRouter } from 'next/navigation'
 import React from 'react'
 
 export const Pagination: React.FC<{
+  basePath?: string
   className?: string
   page: number
   totalPages: number
 }> = (props) => {
   const router = useRouter()
 
-  const { className, page, totalPages } = props
+  const { basePath = '/posts/page', className, page, totalPages } = props
   const hasNextPage = page < totalPages
   const hasPrevPage = page > 1
 
@@ -34,7 +35,7 @@ export const Pagination: React.FC<{
             <PaginationPrevious
               disabled={!hasPrevPage}
               onClick={() => {
-                router.push(`/posts/page/${page - 1}`)
+                router.push(`${basePath}/${page - 1}`)
               }}
             />
           </PaginationItem>
@@ -49,7 +50,7 @@ export const Pagination: React.FC<{
             <PaginationItem>
               <PaginationLink
                 onClick={() => {
-                  router.push(`/posts/page/${page - 1}`)
+                  router.push(`${basePath}/${page - 1}`)
                 }}
               >
                 {page - 1}
@@ -61,7 +62,7 @@ export const Pagination: React.FC<{
             <PaginationLink
               isActive
               onClick={() => {
-                router.push(`/posts/page/${page}`)
+                router.push(`${basePath}/${page}`)
               }}
             >
               {page}
@@ -72,7 +73,7 @@ export const Pagination: React.FC<{
             <PaginationItem>
               <PaginationLink
                 onClick={() => {
-                  router.push(`/posts/page/${page + 1}`)
+                  router.push(`${basePath}/${page + 1}`)
                 }}
               >
                 {page + 1}
@@ -90,7 +91,7 @@ export const Pagination: React.FC<{
             <PaginationNext
               disabled={!hasNextPage}
               onClick={() => {
-                router.push(`/posts/page/${page + 1}`)
+                router.push(`${basePath}/${page + 1}`)
               }}
             />
           </PaginationItem>

--- a/src/components/ui/back-link.tsx
+++ b/src/components/ui/back-link.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import React from 'react'
+
+export const BackLink: React.FC = () => {
+  const router = useRouter()
+
+  return (
+    <button
+      onClick={() => router.back()}
+      className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors mt-2"
+    >
+      ← back
+    </button>
+  )
+}

--- a/src/components/ui/keyword-pill.tsx
+++ b/src/components/ui/keyword-pill.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { cn } from '@/utilities/ui'
+import Link from 'next/link'
+import React from 'react'
+
+import type { Keyword } from '@/payload-types'
+
+export const KeywordPill: React.FC<{
+  keyword: Keyword
+  className?: string
+}> = ({ keyword, className }) => {
+  const slug = keyword.name.replace(/\s+/g, '-')
+
+  return (
+    <Link
+      href={`/keywords/${slug}`}
+      className={cn(
+        'inline-flex items-center px-3 py-1 rounded-full text-md font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors',
+        className,
+      )}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {keyword.name}
+    </Link>
+  )
+}

--- a/src/components/ui/sidebarSections.tsx
+++ b/src/components/ui/sidebarSections.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { cn } from '@/utilities/ui'
+import * as React from 'react'
+
+type SideBarSectionProps = {
+  title: string
+  children: React.ReactNode
+  className?: string
+  style?: React.CSSProperties
+}
+
+type SideBarSubSectionProps = {
+  title: string
+  children: React.ReactNode
+  className?: string
+  style?: React.CSSProperties
+}
+
+export const SideBarSection: React.FC<SideBarSectionProps> = ({
+  title,
+  children,
+  className,
+  style,
+}) => {
+  const headingId = React.useId()
+  return (
+    <section
+      aria-labelledby={headingId}
+      className={cn(className)}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        paddingBottom: '8px',
+        marginBottom: '16px',
+        borderTop: '1px solid var(--theme-border-color)',
+        paddingTop: '12px',
+        marginTop: '8px',
+        ...style,
+      }}
+    >
+      <h4 id={headingId} style={{ fontSize: '18px', fontWeight: 600, marginBottom: '10px' }}>
+        {title}
+      </h4>
+      {children}
+    </section>
+  )
+}
+
+export const SideBarSubSection: React.FC<SideBarSubSectionProps> = ({
+  title,
+  children,
+  className,
+  style,
+}) => {
+  const headingId = React.useId()
+  return (
+    <div role="group" aria-labelledby={headingId} className={cn(className)} style={style}>
+      <h5
+        id={headingId}
+        style={{
+          color: 'var(--theme-text-dim)',
+          fontSize: '16px',
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+          marginBottom: '16px',
+        }}
+      >
+        {title}
+      </h5>
+      {children}
+    </div>
+  )
+}

--- a/src/components/ui/sidebarSections.tsx
+++ b/src/components/ui/sidebarSections.tsx
@@ -4,14 +4,14 @@ import { cn } from '@/utilities/ui'
 import * as React from 'react'
 
 type SideBarSectionProps = {
-  title: string
+  title?: string
   children: React.ReactNode
   className?: string
   style?: React.CSSProperties
 }
 
 type SideBarSubSectionProps = {
-  title: string
+  title?: string
   children: React.ReactNode
   className?: string
   style?: React.CSSProperties
@@ -56,7 +56,15 @@ export const SideBarSubSection: React.FC<SideBarSubSectionProps> = ({
 }) => {
   const headingId = React.useId()
   return (
-    <div role="group" aria-labelledby={headingId} className={cn(className)} style={style}>
+    <div
+      role="group"
+      aria-labelledby={headingId}
+      className={cn(className)}
+      style={{
+        marginBottom: '1rem',
+        ...style,
+      }}
+    >
       <h5
         id={headingId}
         style={{

--- a/src/heros/PostHero/index.tsx
+++ b/src/heros/PostHero/index.tsx
@@ -4,12 +4,13 @@ import React from 'react'
 import type { Post } from '@/payload-types'
 
 import { Media } from '@/components/Media'
+import { KeywordPill } from '@/components/ui/keyword-pill'
 import { formatAuthors } from '@/utilities/formatAuthors'
 
 export const PostHero: React.FC<{
   post: Post
 }> = ({ post }) => {
-  const { categories, heroImage, populatedAuthors, publishedAt, title } = post
+  const { categories, heroImage, keywords, populatedAuthors, publishedAt, title } = post
 
   const hasAuthors =
     populatedAuthors && populatedAuthors.length > 0 && formatAuthors(populatedAuthors) !== ''
@@ -57,6 +58,19 @@ export const PostHero: React.FC<{
                 <p className="text-sm">Date Published</p>
 
                 <time dateTime={publishedAt}>{formatDateTime(publishedAt)}</time>
+              </div>
+            )}
+            {keywords && keywords.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 items-start">
+                {keywords.map((kw) =>
+                  typeof kw === 'object' ? (
+                    <KeywordPill
+                      key={kw.id}
+                      keyword={kw}
+                      className="border border-white/40 bg-white/10 hover:bg-white/20 text-white"
+                    />
+                  ) : null,
+                )}
               </div>
             )}
           </div>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     posts: Post;
     media: Media;
     categories: Category;
+    keywords: Keyword;
     users: User;
     redirects: Redirect;
     forms: Form;
@@ -98,6 +99,7 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
+    keywords: KeywordsSelect<false> | KeywordsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
@@ -263,6 +265,7 @@ export interface Post {
    */
   generateSlug?: boolean | null;
   slug: string;
+  keywords?: (number | Keyword)[] | null;
   broadcasts?: {
     docs?: (number | Broadcast)[];
     hasNextPage?: boolean;
@@ -440,6 +443,16 @@ export interface User {
     | null;
   password?: string | null;
   collection: 'users';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "keywords".
+ */
+export interface Keyword {
+  id: number;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1063,6 +1076,10 @@ export interface PayloadLockedDocument {
         value: number | Category;
       } | null)
     | ({
+        relationTo: 'keywords';
+        value: number | Keyword;
+      } | null)
+    | ({
         relationTo: 'users';
         value: number | User;
       } | null)
@@ -1309,6 +1326,7 @@ export interface PostsSelect<T extends boolean = true> {
       };
   generateSlug?: T;
   slug?: T;
+  keywords?: T;
   broadcasts?: T;
   updatedAt?: T;
   createdAt?: T;
@@ -1425,6 +1443,15 @@ export interface CategoriesSelect<T extends boolean = true> {
         label?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "keywords_select".
+ */
+export interface KeywordsSelect<T extends boolean = true> {
+  name?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -248,15 +248,6 @@ export interface Post {
    * Manually select related posts. If left empty, related posts are chosen automatically by keyword and category.
    */
   relatedPosts?: (number | Post)[] | null;
-  meta?: {
-    title?: string | null;
-    /**
-     * Maximum upload file size: 12MB. Recommended file size for images is <500KB.
-     */
-    image?: (number | null) | Media;
-    description?: string | null;
-  };
-  publishedAt?: string | null;
   authors?: (number | User)[] | null;
   populatedAuthors?:
     | {
@@ -269,6 +260,15 @@ export interface Post {
    */
   generateSlug?: boolean | null;
   slug: string;
+  publishedAt?: string | null;
+  meta?: {
+    title?: string | null;
+    /**
+     * Maximum upload file size: 12MB. Recommended file size for images is <500KB.
+     */
+    image?: (number | null) | Media;
+    description?: string | null;
+  };
   broadcasts?: {
     docs?: (number | Broadcast)[];
     hasNextPage?: boolean;
@@ -1313,14 +1313,6 @@ export interface PostsSelect<T extends boolean = true> {
   content?: T;
   keywords?: T;
   relatedPosts?: T;
-  meta?:
-    | T
-    | {
-        title?: T;
-        image?: T;
-        description?: T;
-      };
-  publishedAt?: T;
   authors?: T;
   populatedAuthors?:
     | T
@@ -1330,6 +1322,14 @@ export interface PostsSelect<T extends boolean = true> {
       };
   generateSlug?: T;
   slug?: T;
+  publishedAt?: T;
+  meta?:
+    | T
+    | {
+        title?: T;
+        image?: T;
+        description?: T;
+      };
   broadcasts?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -226,6 +226,7 @@ export interface Broadcast {
 export interface Post {
   id: number;
   title: string;
+  categories?: (number | Category)[] | null;
   heroImage?: (number | null) | Media;
   content: {
     root: {
@@ -242,7 +243,10 @@ export interface Post {
     };
     [k: string]: unknown;
   };
-  categories?: (number | Category)[] | null;
+  keywords?: (number | Keyword)[] | null;
+  /**
+   * Manually select related posts. If left empty, related posts are chosen automatically by keyword and category.
+   */
   relatedPosts?: (number | Post)[] | null;
   meta?: {
     title?: string | null;
@@ -265,7 +269,6 @@ export interface Post {
    */
   generateSlug?: boolean | null;
   slug: string;
-  keywords?: (number | Keyword)[] | null;
   broadcasts?: {
     docs?: (number | Broadcast)[];
     hasNextPage?: boolean;
@@ -274,6 +277,30 @@ export interface Post {
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories".
+ */
+export interface Category {
+  id: number;
+  title: string;
+  /**
+   * When enabled, the slug will auto-generate from the title field on save and autosave.
+   */
+  generateSlug?: boolean | null;
+  slug: string;
+  parent?: (number | null) | Category;
+  breadcrumbs?:
+    | {
+        doc?: (number | null) | Category;
+        url?: string | null;
+        label?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -396,25 +423,11 @@ export interface FolderInterface {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "categories".
+ * via the `definition` "keywords".
  */
-export interface Category {
+export interface Keyword {
   id: number;
-  title: string;
-  /**
-   * When enabled, the slug will auto-generate from the title field on save and autosave.
-   */
-  generateSlug?: boolean | null;
-  slug: string;
-  parent?: (number | null) | Category;
-  breadcrumbs?:
-    | {
-        doc?: (number | null) | Category;
-        url?: string | null;
-        label?: string | null;
-        id?: string | null;
-      }[]
-    | null;
+  name: string;
   updatedAt: string;
   createdAt: string;
 }
@@ -443,16 +456,6 @@ export interface User {
     | null;
   password?: string | null;
   collection: 'users';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "keywords".
- */
-export interface Keyword {
-  id: number;
-  name: string;
-  updatedAt: string;
-  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1305,9 +1308,10 @@ export interface FormBlockSelect<T extends boolean = true> {
  */
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
+  categories?: T;
   heroImage?: T;
   content?: T;
-  categories?: T;
+  keywords?: T;
   relatedPosts?: T;
   meta?:
     | T
@@ -1326,7 +1330,6 @@ export interface PostsSelect<T extends boolean = true> {
       };
   generateSlug?: T;
   slug?: T;
-  keywords?: T;
   broadcasts?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,6 +7,7 @@ import type { Payload, PayloadRequest } from 'payload'
 import { fileURLToPath } from 'url'
 
 import { Categories } from './collections/Categories'
+import { Keywords } from './collections/Keywords'
 import { Broadcasts } from './collections/Broadcasts'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
@@ -104,7 +105,7 @@ export default buildConfig({
       connectionString: process.env.POSTGRES_URL || '',
     },
   }),
-  collections: [Broadcasts, Pages, Posts, Media, Categories, Users],
+  collections: [Broadcasts, Pages, Posts, Media, Categories, Keywords, Users],
   cors: [getServerSideURL()].filter(Boolean),
   email: resendAdapter({
     apiKey: process.env.RESEND_API_KEY!,

--- a/src/utilities/getRelatedPostsByKeywords.ts
+++ b/src/utilities/getRelatedPostsByKeywords.ts
@@ -5,61 +5,83 @@ import type { Post } from '@/payload-types'
 
 type Args = {
   keywordIds: (string | number)[]
+  categoryIds: (string | number)[]
   currentPostId: string | number
 }
 
 /**
- * Returns up to 3 related posts by cycling through keyword buckets.
+ * Returns up to 3 related posts using a two-phase algorithm:
  *
- * Algorithm:
- * - For each keyword, fetch up to 3 most-recent published posts (in parallel)
- * - Round-robin through the buckets until 3 unique posts are collected
+ * Phase 1 — keyword round-robin (same as before):
+ *   For each keyword, fetch up to 3 recent published posts, then round-robin
+ *   through the buckets until 3 unique posts are collected.
  *
- * Examples:
- * - 1 keyword  → 3 most-recent posts for that keyword
- * - 2 keywords → most-recent for kw1, most-recent for kw2, 2nd most-recent for kw1
- * - 3+ keywords → most-recent for each of the first 3 keywords
+ * Phase 2 — category fallback:
+ *   If fewer than 3 were found, fill remaining slots with the most-recently
+ *   published posts that share any of the current post's categories, excluding
+ *   the current post and any already-selected keyword posts.
  */
 export async function getRelatedPostsByKeywords({
   keywordIds,
+  categoryIds,
   currentPostId,
 }: Args): Promise<Post[]> {
-  if (!keywordIds.length) return []
-
   const payload = await getPayload({ config: configPromise })
 
-  const buckets = await Promise.all(
-    keywordIds.map((keywordId) =>
-      payload
-        .find({
-          collection: 'posts',
-          depth: 1,
-          limit: 3,
-          sort: '-publishedAt',
-          where: {
-            and: [
-              { keywords: { in: [keywordId] } },
-              { id: { not_equals: currentPostId } },
-              { _status: { equals: 'published' } },
-            ],
-          },
-        })
-        .then((r) => r.docs as Post[]),
-    ),
-  )
-
   const selected: Post[] = []
-  const selectedIds = new Set<string | number>()
+  const selectedIds = new Set<string | number>([currentPostId])
 
-  for (let round = 0; round < 3 && selected.length < 3; round++) {
-    for (const bucket of buckets) {
-      if (selected.length >= 3) break
-      const candidate = bucket[round]
-      if (candidate && !selectedIds.has(candidate.id)) {
-        selected.push(candidate)
-        selectedIds.add(candidate.id)
+  // Phase 1: keyword round-robin
+  if (keywordIds.length > 0) {
+    const buckets = await Promise.all(
+      keywordIds.map((keywordId) =>
+        payload
+          .find({
+            collection: 'posts',
+            depth: 1,
+            limit: 3,
+            sort: '-publishedAt',
+            where: {
+              and: [
+                { keywords: { in: [keywordId] } },
+                { id: { not_equals: currentPostId } },
+                { _status: { equals: 'published' } },
+              ],
+            },
+          })
+          .then((r) => r.docs as Post[]),
+      ),
+    )
+
+    for (let round = 0; round < 3 && selected.length < 3; round++) {
+      for (const bucket of buckets) {
+        if (selected.length >= 3) break
+        const candidate = bucket[round]
+        if (candidate && !selectedIds.has(candidate.id)) {
+          selected.push(candidate)
+          selectedIds.add(candidate.id)
+        }
       }
     }
+  }
+
+  // Phase 2: category fallback for remaining slots
+  if (selected.length < 3 && categoryIds.length > 0) {
+    const needed = 3 - selected.length
+    const { docs: categoryFill } = await payload.find({
+      collection: 'posts',
+      depth: 1,
+      limit: needed,
+      sort: '-publishedAt',
+      where: {
+        and: [
+          { categories: { in: categoryIds } },
+          { id: { not_in: [...selectedIds] } },
+          { _status: { equals: 'published' } },
+        ],
+      },
+    })
+    selected.push(...(categoryFill as Post[]))
   }
 
   return selected

--- a/src/utilities/getRelatedPostsByKeywords.ts
+++ b/src/utilities/getRelatedPostsByKeywords.ts
@@ -1,0 +1,66 @@
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+import type { Post } from '@/payload-types'
+
+type Args = {
+  keywordIds: (string | number)[]
+  currentPostId: string | number
+}
+
+/**
+ * Returns up to 3 related posts by cycling through keyword buckets.
+ *
+ * Algorithm:
+ * - For each keyword, fetch up to 3 most-recent published posts (in parallel)
+ * - Round-robin through the buckets until 3 unique posts are collected
+ *
+ * Examples:
+ * - 1 keyword  → 3 most-recent posts for that keyword
+ * - 2 keywords → most-recent for kw1, most-recent for kw2, 2nd most-recent for kw1
+ * - 3+ keywords → most-recent for each of the first 3 keywords
+ */
+export async function getRelatedPostsByKeywords({
+  keywordIds,
+  currentPostId,
+}: Args): Promise<Post[]> {
+  if (!keywordIds.length) return []
+
+  const payload = await getPayload({ config: configPromise })
+
+  const buckets = await Promise.all(
+    keywordIds.map((keywordId) =>
+      payload
+        .find({
+          collection: 'posts',
+          depth: 1,
+          limit: 3,
+          sort: '-publishedAt',
+          where: {
+            and: [
+              { keywords: { in: [keywordId] } },
+              { id: { not_equals: currentPostId } },
+              { _status: { equals: 'published' } },
+            ],
+          },
+        })
+        .then((r) => r.docs as Post[]),
+    ),
+  )
+
+  const selected: Post[] = []
+  const selectedIds = new Set<string | number>()
+
+  for (let round = 0; round < 3 && selected.length < 3; round++) {
+    for (const bucket of buckets) {
+      if (selected.length >= 3) break
+      const candidate = bucket[round]
+      if (candidate && !selectedIds.has(candidate.id)) {
+        selected.push(candidate)
+        selectedIds.add(candidate.id)
+      }
+    }
+  }
+
+  return selected
+}


### PR DESCRIPTION
## Keywords — Admin Tooling, Related Posts & Frontend Discovery

### Summary

This PR introduces the full Keywords feature end-to-end, from content editor tooling in the admin panel through to clickable frontend pill components and keyword-filtered listing pages.

- **Keywords collection** added to Payload CMS with a many-to-many relationship to Posts. Keyword names are automatically trimmed and lowercased on save.
- **Admin UI components** added to the Post editor sidebar:
  - `KeywordsInputField` — autocomplete chip input with inline keyword creation, comma-separated entry, and keyboard navigation
  - `KeywordFrequencyField` — analyzes post body content and displays each keyword's occurrence count with color-coded optimization feedback (missing / low / optimal / high)
  - `SocialPreviewField` — social link preview for the post
- **Related Posts** wired to keywords: the site now surfaces related posts by matching shared keywords first, falling back to category matching. Manual related post selection overrides the automatic algorithm.
- **`KeywordPill` component** (`src/components/ui/keyword-pill.tsx`) — reusable, accessible pill that links to the keyword listing page. Supports className overrides for light-on-dark contexts (PostHero).
- **Post Header (PostHero)** — keyword pills appear to the right of Date Published, styled as white outlined pills against the dark hero background.
- **Post Cards** — keyword pills appear at the bottom-left of each card, below the description. Click propagation is stopped so pills navigate independently from the card link.
- **Keyword listing pages** at `/keywords/[name]` and `/keywords/[name]/page/[pageNumber]` — show all posts tagged with a keyword, sorted most-recent first, with pagination.
- **`Pagination` component** updated with a `basePath` prop (default `/posts/page`) to support pagination on non-posts listing contexts.

### Test plan

- [x] Navigate to a published post with keywords — confirm pills appear in the hero (right of date) and on post cards in listings
- [x] Click a pill from the Post Header — confirm navigation to `/keywords/[name]` showing only posts tagged with that keyword, sorted newest first
- [x] Click a pill from a Post Card — confirm the pill navigates to the keyword page without triggering the card's own link
- [x] Verify keyword listing pagination works correctly when a keyword has more than 12 posts
- [x] Open a post in the admin panel — verify `KeywordsInputField` autocomplete, inline creation, and `KeywordFrequencyField` color-coded counts render correctly
- [x] Confirm posts with no keywords render cleanly with no pill rows
- [x] `pnpm build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)