### PR TITLE
Categories - Adds Subscribers to New Category

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,5 @@ PREVIEW_SECRET=YOUR_SECRET_HERE
 # Resend used for email
 RESEND_API_KEY=your_resend_api_key
 RESEND_FROM=youraddress@email.com
+# Resend webhook signing secret (Resend Dashboard → Webhooks → signing secret)
+RESEND_WEBHOOK_SECRET=your_resend_webhook_signing_secret

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-hook-form": "7.45.4",
     "resend": "^6.6.0",
     "sharp": "0.34.2",
+    "svix": "^1.92.2",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       sharp:
         specifier: 0.34.2
         version: 0.34.2
+      svix:
+        specifier: ^1.92.2
+        version: 1.92.2
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.6.0
@@ -4585,6 +4588,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
@@ -4689,6 +4695,9 @@ packages:
 
   svix@1.76.1:
     resolution: {integrity: sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==}
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -9906,6 +9915,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   state-local@1.0.7: {}
 
   std-env@3.10.0: {}
@@ -10036,6 +10050,10 @@ snapshots:
       fast-sha256: 1.3.0
       url-parse: 1.5.10
       uuid: 10.0.0
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   symbol-tree@3.2.4: {}
 

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from 'next/server'
+import { Webhook } from 'svix'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { EmailSetting } from '../../../../payload-types'
+import { removeContactFromResendAudience } from '../../../../resend/contacts'
+
+interface ResendContactUpdatedData {
+  audience_id: string
+  contact_id: string
+  email: string
+  unsubscribed: boolean
+}
+
+interface ResendWebhookEvent {
+  type: string
+  created_at: string
+  data: ResendContactUpdatedData
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const secret = process.env.RESEND_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[Resend Webhook] RESEND_WEBHOOK_SECRET not set')
+    return new Response('Webhook secret not configured', { status: 500 })
+  }
+
+  const svixId = req.headers.get('svix-id')
+  const svixTimestamp = req.headers.get('svix-timestamp')
+  const svixSignature = req.headers.get('svix-signature')
+
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return new Response('Missing svix headers', { status: 400 })
+  }
+
+  const rawBody = await req.text()
+  let event: ResendWebhookEvent
+
+  try {
+    const wh = new Webhook(secret)
+    event = wh.verify(rawBody, {
+      'svix-id': svixId,
+      'svix-timestamp': svixTimestamp,
+      'svix-signature': svixSignature,
+    }) as ResendWebhookEvent
+  } catch {
+    return new Response('Invalid webhook signature', { status: 400 })
+  }
+
+  if (event.type === 'contact.updated' && event.data.unsubscribed) {
+    try {
+      const payload = await getPayload({ config })
+      const emailSettings = (await payload.findGlobal({
+        slug: 'email-settings',
+        depth: 0,
+      })) as EmailSetting
+
+      const audienceId = emailSettings.resendAudienceId
+      if (audienceId) {
+        await removeContactFromResendAudience(audienceId, event.data.email)
+        console.info('[Resend Webhook] Removed globally unsubscribed contact', {
+          email: event.data.email,
+        })
+      }
+    } catch (err) {
+      console.error('[Resend Webhook] Failed to process unsubscribe', err)
+      return new Response('Internal error', { status: 500 })
+    }
+  }
+
+  return new Response('OK', { status: 200 })
+}

--- a/src/collections/Categories/hooks/syncToResendTopic.ts
+++ b/src/collections/Categories/hooks/syncToResendTopic.ts
@@ -1,12 +1,11 @@
 import type { CollectionBeforeChangeHook } from 'payload'
-import type { Category, EmailSetting } from '../../../payload-types'
-import { createResendTopic, updateResendTopic, subscribeAllAudienceContactsToTopic } from '../../../resend/topics'
+import type { Category } from '../../../payload-types'
+import { createResendTopic, updateResendTopic } from '../../../resend/topics'
 
 export const syncToResendTopic: CollectionBeforeChangeHook<Category> = async ({
   data,
   operation,
   originalDoc,
-  req,
 }) => {
   try {
     if (operation === 'create') {
@@ -17,25 +16,7 @@ export const syncToResendTopic: CollectionBeforeChangeHook<Category> = async ({
         data.title as string,
         data.description as string | undefined,
       )
-      if (topicId) {
-        data.resendTopicId = topicId
-        // Fire-and-forget: subscribe all existing audience contacts to the new topic.
-        // Not awaited so the Category save is not delayed by the bulk operation.
-        void (async () => {
-          try {
-            const emailSettings = (await req.payload.findGlobal({
-              slug: 'email-settings',
-              depth: 0,
-            })) as EmailSetting
-            const audienceId = emailSettings.resendAudienceId
-            if (audienceId) {
-              await subscribeAllAudienceContactsToTopic(audienceId, topicId)
-            }
-          } catch (err) {
-            console.error('[Categories] Bulk subscribe to new topic failed', err)
-          }
-        })()
-      }
+      if (topicId) data.resendTopicId = topicId
     } else if (operation === 'update' && originalDoc?.resendTopicId) {
       const titleChanged = data.title !== undefined && data.title !== originalDoc?.title
       const descriptionChanged =

--- a/src/collections/Categories/hooks/syncToResendTopic.ts
+++ b/src/collections/Categories/hooks/syncToResendTopic.ts
@@ -1,11 +1,12 @@
 import type { CollectionBeforeChangeHook } from 'payload'
-import type { Category } from '../../../payload-types'
-import { createResendTopic, updateResendTopic } from '../../../resend/topics'
+import type { Category, EmailSetting } from '../../../payload-types'
+import { createResendTopic, updateResendTopic, subscribeAllAudienceContactsToTopic } from '../../../resend/topics'
 
 export const syncToResendTopic: CollectionBeforeChangeHook<Category> = async ({
   data,
   operation,
   originalDoc,
+  req,
 }) => {
   try {
     if (operation === 'create') {
@@ -16,7 +17,25 @@ export const syncToResendTopic: CollectionBeforeChangeHook<Category> = async ({
         data.title as string,
         data.description as string | undefined,
       )
-      if (topicId) data.resendTopicId = topicId
+      if (topicId) {
+        data.resendTopicId = topicId
+        // Fire-and-forget: subscribe all existing audience contacts to the new topic.
+        // Not awaited so the Category save is not delayed by the bulk operation.
+        void (async () => {
+          try {
+            const emailSettings = (await req.payload.findGlobal({
+              slug: 'email-settings',
+              depth: 0,
+            })) as EmailSetting
+            const audienceId = emailSettings.resendAudienceId
+            if (audienceId) {
+              await subscribeAllAudienceContactsToTopic(audienceId, topicId)
+            }
+          } catch (err) {
+            console.error('[Categories] Bulk subscribe to new topic failed', err)
+          }
+        })()
+      }
     } else if (operation === 'update' && originalDoc?.resendTopicId) {
       const titleChanged = data.title !== undefined && data.title !== originalDoc?.title
       const descriptionChanged =

--- a/src/resend/contacts.ts
+++ b/src/resend/contacts.ts
@@ -109,3 +109,25 @@ export async function addContactToResendSegment(
     }
   }
 }
+
+export async function removeContactFromResendAudience(
+  audienceId: string,
+  email: string,
+): Promise<void> {
+  const resend = getResendClient()
+  if (!resend) return
+
+  const normalizedEmail = email.trim().toLowerCase()
+
+  try {
+    const { error } = await resend.contacts.remove({ audienceId, email: normalizedEmail })
+    if (error) {
+      console.error('[Resend Contacts] Failed to remove contact from audience', {
+        email: normalizedEmail,
+        error,
+      })
+    }
+  } catch (err) {
+    console.error('[Resend Contacts] Exception removing contact from audience', err)
+  }
+}

--- a/src/resend/index.ts
+++ b/src/resend/index.ts
@@ -1,7 +1,7 @@
 // src/resend/index.ts
 export { getResendClient, retryResendCall, isRateLimitError, sleep } from './client'
 export type { CreateResendContactResult, AddToResendSegmentResult } from './contacts'
-export { createResendContact, addContactToResendSegment } from './contacts'
+export { createResendContact, addContactToResendSegment, removeContactFromResendAudience } from './contacts'
 export type { SendWelcomeEmailResult, HandleNewsletterSubscribeResult } from './newsletter'
 export { sendWelcomeEmail, handleNewsletterSubscribe } from './newsletter'
 export type {
@@ -16,5 +16,4 @@ export {
   updateResendTopic,
   deleteResendTopic,
   subscribeContactToTopic,
-  subscribeAllAudienceContactsToTopic,
 } from './topics'

--- a/src/resend/index.ts
+++ b/src/resend/index.ts
@@ -16,4 +16,5 @@ export {
   updateResendTopic,
   deleteResendTopic,
   subscribeContactToTopic,
+  subscribeAllAudienceContactsToTopic,
 } from './topics'

--- a/src/resend/newsletter.ts
+++ b/src/resend/newsletter.ts
@@ -1,12 +1,11 @@
 // src/resend/newsletter.ts
 import type { Payload } from 'payload'
 import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html'
-import type { Category, EmailLayout, EmailSetting } from '../payload-types'
+import type { EmailLayout, EmailSetting } from '../payload-types'
 import { getResendClient, retryResendCall } from './client'
 import { renderEmailTemplate } from './template'
 import { createResendContact, addContactToResendSegment } from './contacts'
 import type { CreateResendContactResult, AddToResendSegmentResult } from './contacts'
-import { subscribeContactToTopic } from './topics'
 
 interface ResendEmailData {
   id: string
@@ -101,12 +100,6 @@ export async function handleNewsletterSubscribe(
   const segment =
     contact.status === 'disabled' ? undefined : await addContactToResendSegment(payload, email)
 
-  // Subscribe to all Category topics (idempotent — safe to call on re-subscribe so new
-  // topics added since last sign-up are picked up automatically).
-  if (contact.status !== 'disabled') {
-    await subscribeToAllCategoryTopics(payload, email)
-  }
-
   // Only send welcome email on first subscribe.
   if (contact.status === 'created') {
     const welcomeEmail = await sendWelcomeEmail(payload, email)
@@ -116,22 +109,3 @@ export async function handleNewsletterSubscribe(
   return { contact, segment }
 }
 
-async function subscribeToAllCategoryTopics(payload: Payload, email: string): Promise<void> {
-  try {
-    const result = await payload.find({
-      collection: 'categories',
-      limit: 200,
-      depth: 0,
-    })
-
-    const topicIds = (result.docs as Category[])
-      .map((c) => c.resendTopicId)
-      .filter((id): id is string => Boolean(id))
-
-    await Promise.allSettled(
-      topicIds.map((topicId) => subscribeContactToTopic(topicId, email)),
-    )
-  } catch (err) {
-    console.error('[Newsletter] Failed to subscribe contact to category topics', err)
-  }
-}

--- a/src/resend/topics.ts
+++ b/src/resend/topics.ts
@@ -14,7 +14,7 @@ export async function createResendTopic(
     const { data, error } = await resend.topics.create({
       name,
       ...(description ? { description } : {}),
-      defaultSubscription: 'opt_out',
+      defaultSubscription: 'opt_in',
       visibility: 'public',
     } as CreateTopicOptionsWithVisibility)
     if (error || !data) {
@@ -81,45 +81,3 @@ export async function subscribeContactToTopic(topicId: string, email: string): P
   }
 }
 
-interface ResendContact {
-  id: string
-  email: string
-  unsubscribed: boolean
-}
-
-interface ResendContactListResponse {
-  object: 'list'
-  data: ResendContact[]
-}
-
-export async function subscribeAllAudienceContactsToTopic(
-  audienceId: string,
-  topicId: string,
-): Promise<void> {
-  const resend = getResendClient()
-  if (!resend) return
-
-  try {
-    const { data, error } = (await resend.contacts.list({ audienceId })) as {
-      data: ResendContactListResponse | null
-      error: { message: string } | null
-    }
-    if (error || !data) {
-      console.error('[Resend Topics] Failed to list contacts for bulk topic subscribe', {
-        audienceId,
-        error,
-      })
-      return
-    }
-
-    const emails = data.data.filter((c) => !c.unsubscribed).map((c) => c.email)
-
-    await Promise.allSettled(emails.map((email) => subscribeContactToTopic(topicId, email)))
-    console.info('[Resend Topics] Bulk subscribed contacts to new topic', {
-      topicId,
-      count: emails.length,
-    })
-  } catch (err) {
-    console.error('[Resend Topics] Exception bulk subscribing contacts to topic', err)
-  }
-}

--- a/src/resend/topics.ts
+++ b/src/resend/topics.ts
@@ -80,3 +80,46 @@ export async function subscribeContactToTopic(topicId: string, email: string): P
     console.error('[Resend Topics] Exception subscribing contact to topic', err)
   }
 }
+
+interface ResendContact {
+  id: string
+  email: string
+  unsubscribed: boolean
+}
+
+interface ResendContactListResponse {
+  object: 'list'
+  data: ResendContact[]
+}
+
+export async function subscribeAllAudienceContactsToTopic(
+  audienceId: string,
+  topicId: string,
+): Promise<void> {
+  const resend = getResendClient()
+  if (!resend) return
+
+  try {
+    const { data, error } = (await resend.contacts.list({ audienceId })) as {
+      data: ResendContactListResponse | null
+      error: { message: string } | null
+    }
+    if (error || !data) {
+      console.error('[Resend Topics] Failed to list contacts for bulk topic subscribe', {
+        audienceId,
+        error,
+      })
+      return
+    }
+
+    const emails = data.data.filter((c) => !c.unsubscribed).map((c) => c.email)
+
+    await Promise.allSettled(emails.map((email) => subscribeContactToTopic(topicId, email)))
+    console.info('[Resend Topics] Bulk subscribed contacts to new topic', {
+      topicId,
+      count: emails.length,
+    })
+  } catch (err) {
+    console.error('[Resend Topics] Exception bulk subscribing contacts to topic', err)
+  }
+}


### PR DESCRIPTION
## Summary

- **Switch `defaultSubscription` from `opt_out` to `opt_in`** on Resend Topics — Resend now handles audience filtering server-side, eliminating the N × M API call pattern (one per contact per topic) that wouldn't scale past a few hundred subscribers
- **Remove explicit topic subscription logic** from the new-subscriber flow (`subscribeToAllCategoryTopics`) and from Category create hooks — both are now redundant
- **Add `removeContactFromResendAudience`** to the Resend contacts layer
- **New `POST /api/webhooks/resend` endpoint** — verifies Resend webhook signatures via svix and deletes globally-unsubscribed contacts from the audience, so they're never reached again by future topic broadcasts

## Behavior change

| Action                        | Before                                                     | After                                                           |
| ----------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
| New Category created          | Creates topic + N API calls to bulk-subscribe all contacts | Creates topic only — Resend auto-includes all audience contacts |
| New subscriber joins          | Creates contact + subscribes to every existing topic       | Creates contact + adds to segment — auto-opted into all topics  |
| Contact globally unsubscribes | Stays in audience indefinitely                             | Webhook deletes them from the audience immediately              |

## Setup required

1. Add `RESEND_WEBHOOK_SECRET` to `.env` (Resend Dashboard → Webhooks → signing secret)
2. Register `POST https://your-domain/api/webhooks/resend` in Resend Dashboard with the `contact.updated` event
3. For local webhook testing: add your Vercel preview URL as a second webhook endpoint

## Test plan

- [x] Create a new Payload Category → one Resend Topic created, no bulk-subscribe log lines
- [x] Sign up with a new email → contact appears in Resend audience; included in topic broadcasts automatically
- [ ] Click the unsubscribe link in a test broadcast → contact is deleted from the Resend audience
- [x] `pnpm tsc --noEmit` — zero errors